### PR TITLE
[FEAT] 호스트의 현재 방송 상태, RTMP 요청 시 방송 시작 설정 API 작성 / 방송 정보 업데이트 시 정보가 reflect 되도록 코드 수정

### DIFF
--- a/backend/mainServer/src/dto/memoryDbDto.ts
+++ b/backend/mainServer/src/dto/memoryDbDto.ts
@@ -21,6 +21,7 @@ export class MemoryDbDto {
   };
   category: string = '';
   tags: Array<string> = [];
+  state : boolean = false;
 
   constructor(data?: Partial<MemoryDbDto>) {
     if (data) {

--- a/backend/mainServer/src/dto/memoryDbDto.ts
+++ b/backend/mainServer/src/dto/memoryDbDto.ts
@@ -30,7 +30,7 @@ export class MemoryDbDto {
   }
 }
 
-export function updateMemoryDbDtoFromLiveVideoRequestDto(
+export function memoryDbDtoFromLiveVideoRequestDto(
   memoryDbDto: MemoryDbDto,
   liveVideoDto: LiveVideoRequestDto
 ): MemoryDbDto {

--- a/backend/mainServer/src/host/host.controller.ts
+++ b/backend/mainServer/src/host/host.controller.ts
@@ -4,7 +4,7 @@ import { hostKeyPairDto } from '../dto/hostKeyPairDto.js';
 import { Request, Response } from 'express';
 import { ApiCreatedResponse, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MemoryDBService } from '../memory-db/memory-db.service.js';
-import { updateMemoryDbDtoFromLiveVideoRequestDto } from '../dto/memoryDbDto.js';
+import { memoryDbDtoFromLiveVideoRequestDto } from '../dto/memoryDbDto.js';
 import { LiveVideoRequestDto } from '../dto/liveVideoDto.js';
 
 
@@ -53,8 +53,11 @@ export class HostController {
   async findSession(@Query('streamKey') streamKey: string, @Req() req: Request, @Res() res: Response) {
     try {
       const sessionKey = this.memoryDBService.findByStreamKey(streamKey);
-      if (!sessionKey)
+      if (!sessionKey) {
         throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
+      }
+      sessionKey.state = true;
+      this.memoryDBService.updateBySessionKey(streamKey, sessionKey)
       res.status(HttpStatus.OK).json({'session-key': sessionKey});
     } catch (error) {
       if ((error as { status: number }).status === 400) {
@@ -78,7 +81,7 @@ export class HostController {
       const nowUserData = this.memoryDBService.findByUserId(requestDto.userId);
       if (!nowUserData)
         throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
-      this.memoryDBService.update(requestDto.userId, updateMemoryDbDtoFromLiveVideoRequestDto(nowUserData, requestDto));
+      this.memoryDBService.updateByUserId(requestDto.userId, memoryDbDtoFromLiveVideoRequestDto(nowUserData, requestDto));
       res.status(HttpStatus.OK).send();
     } catch (error) {
       if ((error as { status: number }).status === 400) {

--- a/backend/mainServer/src/host/host.controller.ts
+++ b/backend/mainServer/src/host/host.controller.ts
@@ -57,7 +57,7 @@ export class HostController {
         throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
       }
       sessionKey.state = true;
-      this.memoryDBService.updateBySessionKey(streamKey, sessionKey)
+      this.memoryDBService.updateBySessionKey(streamKey, sessionKey);
       res.status(HttpStatus.OK).json({'session-key': sessionKey});
     } catch (error) {
       if ((error as { status: number }).status === 400) {
@@ -83,9 +83,9 @@ export class HostController {
         throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
       this.memoryDBService.updateByUserId(requestDto.userId, memoryDbDtoFromLiveVideoRequestDto(nowUserData, requestDto));
       res.status(HttpStatus.OK).json({
-        status : "success",
+        status : 'success',
         data : requestDto
-      })
+      });
     } catch (error) {
       if ((error as { status: number }).status === 400) {
         res.status(HttpStatus.BAD_REQUEST).json({
@@ -100,9 +100,9 @@ export class HostController {
     }
   }
 
-  @Get("/state")
-  @ApiOperation({summary : "Response this session is live", description: "현재 방송 세션이 라이브 상태인지 반환합니다."})
-  @ApiResponse({status : 200, description : "현재 방송 상태에 대한 응답"})
+  @Get('/state')
+  @ApiOperation({summary : 'Response this session is live", description: "현재 방송 세션이 라이브 상태인지 반환합니다.'})
+  @ApiResponse({status : 200, description : '현재 방송 상태에 대한 응답'})
   async getBroadcastState(@Query('sessionKey') sessionKey : string, @Res() res : Response) {
     const liveState = this.memoryDBService.findBySessionKey(sessionKey);
     if (!liveState) {
@@ -110,6 +110,6 @@ export class HostController {
     }
     res.status(200).json({
       state : liveState.state
-    })
+    });
   }
 }

--- a/backend/mainServer/src/host/host.controller.ts
+++ b/backend/mainServer/src/host/host.controller.ts
@@ -93,4 +93,17 @@ export class HostController {
       }
     }
   }
+
+  @Get("/state")
+  @ApiOperation({summary : "Response this session is live", description: "현재 방송 세션이 라이브 상태인지 반환합니다."})
+  @ApiResponse({status : 200, description : "현재 방송 상태에 대한 응답"})
+  async getBroadcastState(@Query('sessionKey') sessionKey : string, @Res() res : Response) {
+    const liveState = this.memoryDBService.findBySessionKey(sessionKey);
+    if (!liveState) {
+      throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
+    }
+    res.status(200).json({
+      state : liveState.state
+    })
+  }
 }

--- a/backend/mainServer/src/host/host.controller.ts
+++ b/backend/mainServer/src/host/host.controller.ts
@@ -82,7 +82,10 @@ export class HostController {
       if (!nowUserData)
         throw new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
       this.memoryDBService.updateByUserId(requestDto.userId, memoryDbDtoFromLiveVideoRequestDto(nowUserData, requestDto));
-      res.status(HttpStatus.OK).send();
+      res.status(HttpStatus.OK).json({
+        status : "success",
+        data : requestDto
+      })
     } catch (error) {
       if ((error as { status: number }).status === 400) {
         res.status(HttpStatus.BAD_REQUEST).json({

--- a/backend/mainServer/src/memory-db/memory-db.service.ts
+++ b/backend/mainServer/src/memory-db/memory-db.service.ts
@@ -36,8 +36,15 @@ export class MemoryDBService {
     this.db.push(newItem);
   }
 
-  update(userId: string, updatedItem: Partial<MemoryDbDto>): boolean {
+  updateByUserId(userId: string, updatedItem: Partial<MemoryDbDto>): boolean {
     const index = this.db.findIndex(item => item.userId === userId);
+    if (index === -1) return false;
+    this.db[index] = { ...this.db[index], ...updatedItem } as MemoryDbDto;
+    return true;
+  }
+
+  updateBySessionKey(sessionKey: string, updatedItem: Partial<MemoryDbDto>): boolean {
+    const index = this.db.findIndex(item => item.sessionKey === sessionKey);
     if (index === -1) return false;
     this.db[index] = { ...this.db[index], ...updatedItem } as MemoryDbDto;
     return true;

--- a/backend/mainServer/src/memory-db/memory-db.service.ts
+++ b/backend/mainServer/src/memory-db/memory-db.service.ts
@@ -23,6 +23,10 @@ export class MemoryDBService {
     return this.db.find(item => item.streamKey === streamKey);
   }
 
+  findBySessionKey(sessionKey: string): MemoryDbDto | undefined {
+    return this.db.find(item => item.sessionKey === sessionKey);
+  }
+  
   getRandomBroadcastInfo(count: number) {
     return getRandomElementsFromArray(this.db, count);
   }


### PR DESCRIPTION
## 🚀 Issue Number
<!-- - resolve: #{Number} -->
- resolve: #131 
- resolve: #132

## 주요 작업
<!-- 문제 상황 정의 -->
- 기존 인-메모리 db에 방송 진행 여부 속성 추가
- get 요청으로 방송 진행 여부 polling api 작성
- rtmp 서버가 메인 서버 연결 시 방송 상태 전환 기능 추가
- 방송 정보 업데이트 시 정보가 reflect 되도록 코드 수정


## 고민과 해결 과정
<!-- 변경 사항 -->


## 📸 Screenshots


## 🔜 추가 내용 (선택)
