### PR TITLE
[FEAT] 호스트 업데이트 및 폴링을 통해 방송 여부 판단

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-
 import { theme } from './styles/theme';
 import { MainPage, ClientPage, HostPage } from './pages';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -10,13 +9,14 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
-        <Router>
+        <Router future={{ 
+          v7_startTransition: true,
+          v7_relativeSplatPath: true 
+        }}>
           <Routes>
             <Route path="/" element={<MainPage />} />
-
             <Route path="/live" element={<ClientPage />} />
             <Route path="/live/:id" element={<ClientPage />} />
-
             <Route path="/host" element={<HostPage />} />
             <Route path="/host/:id" element={<HostPage />} />
           </Routes>

--- a/frontend/src/apis/fetchBroadcastStatus.ts
+++ b/frontend/src/apis/fetchBroadcastStatus.ts
@@ -1,0 +1,12 @@
+import { fetchInstance } from '.';
+
+export type BroadcastStatusResponse = {
+  status: boolean;
+};
+
+export const fetchBroadcastStatus = async (): Promise<BroadcastStatusResponse> => {
+  const response = await fetchInstance().get<BroadcastStatusResponse>('/host/status');
+  return {
+    status: response.data.status
+  };
+};

--- a/frontend/src/apis/fetchBroadcastStatus.ts
+++ b/frontend/src/apis/fetchBroadcastStatus.ts
@@ -1,12 +1,20 @@
+import { getSessionKey } from '@utils/streamKey';
 import { fetchInstance } from '.';
 
 export type BroadcastStatusResponse = {
-  status: boolean;
+  state: boolean;
 };
 
 export const fetchBroadcastStatus = async (): Promise<BroadcastStatusResponse> => {
-  const response = await fetchInstance().get<BroadcastStatusResponse>('/host/status');
+  const sessionKey = getSessionKey();
+
+  const response = await fetchInstance().get<BroadcastStatusResponse>('/host/state', {
+    params: {
+      sessionKey
+    }
+  });
+
   return {
-    status: response.data.status
+    state: response.data.state
   };
 };

--- a/frontend/src/apis/queries/host/useBroadcastStatusPolling.ts
+++ b/frontend/src/apis/queries/host/useBroadcastStatusPolling.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchBroadcastStatus } from '@apis/fetchBroadcastStatus';
+
+export const useBroadcastStatusPolling = (pollingInterVal = 10000) => {
+  return useQuery({
+    queryKey: ['broadcastStatus'],
+    queryFn: fetchBroadcastStatus,
+    refetchInterval: pollingInterVal,
+    refetchIntervalInBackground: true,
+    refetchOnWindowFocus: true,
+    retry: 3,
+    initialData: { status: false },
+    select: (data) => data.status
+  });
+};

--- a/frontend/src/apis/queries/host/useBroadcastStatusPolling.ts
+++ b/frontend/src/apis/queries/host/useBroadcastStatusPolling.ts
@@ -3,13 +3,13 @@ import { fetchBroadcastStatus } from '@apis/fetchBroadcastStatus';
 
 export const useBroadcastStatusPolling = (pollingInterVal = 10000) => {
   return useQuery({
-    queryKey: ['broadcastStatus'],
+    queryKey: ['broadcastState'],
     queryFn: fetchBroadcastStatus,
     refetchInterval: pollingInterVal,
     refetchIntervalInBackground: true,
     refetchOnWindowFocus: true,
     retry: 3,
-    initialData: { status: false },
-    select: (data) => data.status
+    initialData: { state: false },
+    select: (data) => data.state
   });
 };

--- a/frontend/src/apis/queries/host/useUpdateHost.ts
+++ b/frontend/src/apis/queries/host/useUpdateHost.ts
@@ -1,0 +1,19 @@
+import { HostInfo, updateHost } from '@apis/updateHost';
+import { useMutation, UseMutationResult } from '@tanstack/react-query';
+
+type Params = {
+  onSuccess?: (data: HostInfo) => void;
+  onError?: (error: Error) => void;
+};
+
+export default function useUpdateHost({ onSuccess, onError }: Params = {}): UseMutationResult<
+  HostInfo,
+  Error,
+  HostInfo
+> {
+  return useMutation({
+    mutationFn: (hostInfo: HostInfo) => updateHost(hostInfo),
+    onSuccess,
+    onError
+  });
+}

--- a/frontend/src/apis/updateHost.ts
+++ b/frontend/src/apis/updateHost.ts
@@ -4,7 +4,7 @@ import { fetchInstance } from '.';
 export interface HostInfo {
   userId: string;
   liveTitle: string;
-  defaultThumbnailImageUrl: '';
+  defaultThumbnailImageUrl: string;
   category: string;
   tags: string[];
 }

--- a/frontend/src/apis/updateHost.ts
+++ b/frontend/src/apis/updateHost.ts
@@ -1,0 +1,16 @@
+import { AxiosResponse } from 'axios';
+import { fetchInstance } from '.';
+
+export interface HostInfo {
+  userId: string;
+  liveTitle: string;
+  defaultThumbnailImageUrl: '';
+  category: string;
+  tags: string[];
+}
+
+export const updateHost = async (hostInfo: HostInfo): Promise<HostInfo> => {
+  const response: AxiosResponse<HostInfo> = await fetchInstance().post('/host/update', hostInfo);
+
+  return response.data;
+};

--- a/frontend/src/components/host/Player.tsx
+++ b/frontend/src/components/host/Player.tsx
@@ -10,13 +10,17 @@ interface PlayerProps {
   onStreaming: boolean;
 }
 
+interface ContainerProps {
+  $onStreaming: boolean;
+}
+
 export default function Player({ onStreaming }: PlayerProps) {
   const { isOpen, closeModal, openModal } = useModal();
   const createPortal = usePortal();
 
   return (
     <>
-      <Container onStreaming={onStreaming}>
+      <Container $onStreaming={onStreaming}>
         <StreamingView onStreaming={onStreaming} openModal={openModal} />
       </Container>
       <StreamingStatus onStreaming={onStreaming} />
@@ -25,8 +29,8 @@ export default function Player({ onStreaming }: PlayerProps) {
   );
 }
 
-const Container = styled.div<{ onStreaming: boolean }>`
-  background: ${({ onStreaming }) => (onStreaming ? '#000' : `url(${playerLoading}) no-repeat center / cover`)};
+const Container = styled.div<ContainerProps>`
+  background: ${({ $onStreaming }) => ($onStreaming ? '#000' : `url(${playerLoading}) no-repeat center / cover`)};
   width: 100%;
   padding-top: 56.25%;
   position: relative;

--- a/frontend/src/components/host/Setting.tsx
+++ b/frontend/src/components/host/Setting.tsx
@@ -1,18 +1,15 @@
 import styled from 'styled-components';
 import Player from './Player';
 import SettingForm from './SettingForm';
-import { useState } from 'react';
+import { useBroadcastStatusPolling } from '@apis/queries/host/useBroadcastStatusPolling';
 
 export default function Setting() {
-  const [onStreaming, setOnStreaming] = useState(false);
-  const toggleStreaming = () => {
-    setOnStreaming((prev) => !prev);
-  };
+  const { data: onStreaming } = useBroadcastStatusPolling();
 
   return (
     <Container>
       <Player onStreaming={onStreaming} />
-      <SettingForm toggleStreaming={toggleStreaming} />
+      <SettingForm />
     </Container>
   );
 }

--- a/frontend/src/components/host/SettingInfo.tsx
+++ b/frontend/src/components/host/SettingInfo.tsx
@@ -4,7 +4,7 @@ import DownloadIcon from '@assets/download.svg';
 import { getOrCreateId } from '@utils/id';
 import useFetchStreamKey from '@apis/queries/host/useFetchStreamKey';
 import { useEffect } from 'react';
-import { setStreamKey } from '@utils/streamKey';
+import { setSessionKey, setStreamKey } from '@utils/streamKey';
 
 interface SettingInfoProps {
   closeModal: () => void;
@@ -13,7 +13,10 @@ interface SettingInfoProps {
 export default function SettingInfo({ closeModal }: SettingInfoProps) {
   const userId = getOrCreateId();
   const { mutate: fetchKey, data } = useFetchStreamKey({
-    onSuccess: ({ streamKey }) => setStreamKey(streamKey)
+    onSuccess: ({ streamKey, sessionKey }) => {
+      setStreamKey(streamKey);
+      setSessionKey(sessionKey);
+    }
   });
 
   useEffect(() => {

--- a/frontend/src/components/host/StreamingStatus.tsx
+++ b/frontend/src/components/host/StreamingStatus.tsx
@@ -7,7 +7,7 @@ interface StreamingStatusProps {
 export default function StreamingStatus({ onStreaming }: StreamingStatusProps) {
   return (
     <StatusContainer>
-      <StatusIcon onStreaming={onStreaming} />
+      <StatusIcon $onStreaming={onStreaming} />
       {onStreaming ? '온라인' : '오프라인'}
     </StatusContainer>
   );
@@ -25,10 +25,10 @@ const StatusContainer = styled.strong`
   color: #ffffff;
 `;
 
-const StatusIcon = styled.i<{ onStreaming: boolean }>`
+const StatusIcon = styled.i<{ $onStreaming: boolean }>`
   width: 8px;
   height: 8px;
-  background: ${({ onStreaming }) => (onStreaming ? 'red' : 'rgba(255, 255, 255, 0.5)')};
+  background: ${({ $onStreaming }) => ($onStreaming ? 'red' : 'rgba(255, 255, 255, 0.5)')};
   border-radius: 4px;
   margin-right: 8px;
   position: relative;

--- a/frontend/src/utils/streamKey.ts
+++ b/frontend/src/utils/streamKey.ts
@@ -1,6 +1,34 @@
-type Key = 'StreamKey';
+const STORAGE_KEYS = {
+  STREAM: 'STREAM_KEY',
+  SESSION: 'SESSION_KEY'
+};
 
-const key: Key = 'StreamKey';
+export const getStreamKey = () => {
+  const streamKey = localStorage.getItem(STORAGE_KEYS.STREAM);
 
-export const getStreamKey = (): string => localStorage.getItem(key) ?? '';
-export const setStreamKey = (StreamKey: string): void => localStorage.setItem(key, StreamKey);
+  return streamKey ?? '';
+};
+
+export const setStreamKey = (key: string) => {
+  if (!key.trim()) {
+    localStorage.removeItem(STORAGE_KEYS.STREAM);
+    return;
+  }
+
+  localStorage.setItem(STORAGE_KEYS.STREAM, key);
+};
+
+export const getSessionKey = (): string => {
+  const sessionKey = localStorage.getItem(STORAGE_KEYS.SESSION);
+
+  return sessionKey ?? '';
+};
+
+export const setSessionKey = (key: string): void => {
+  if (!key.trim()) {
+    localStorage.removeItem(STORAGE_KEYS.SESSION);
+    return;
+  }
+  
+  localStorage.setItem(STORAGE_KEYS.SESSION, key);
+};


### PR DESCRIPTION
## 🚀 Issue Number
- resolve: #119 
- resolve: #120 

## 주요 작업
<!-- 문제 상황 정의 -->
- 업데이트 버튼 클릭 시 테그, 타이틀, 카테고리 등 입력한 인풋 정보를 업데이트 합니다.
- 10초마다 api를 호출하여 현재 방송 상태를 확인합니다. 방송 여부에 따라 플레이어에 렌더링합니다.


## 고민과 해결 과정
<!-- 변경 사항 -->
호스트 폼에 있는 상태가 많아져 리듀서로 분리 예정입니다. 
추후 태그 컴포넌트를 분리하여 복잡도를 낮출 예정입니다.


## 📸 Screenshots
<img width="1551" alt="스크린샷 2024-11-19 오후 4 07 19" src="https://github.com/user-attachments/assets/b177c79d-1193-46ac-8c80-63a69609a5d5">


## 🔜 추가 내용 (선택)
