### PR TITLE
[FEAT] id 생성 고차함수 구현 및 기존 관련 id 사용 로직 리팩토링

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,10 +4,9 @@ import { theme } from './styles/theme';
 import { MainPage, ClientPage, HostPage } from './pages';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@apis/index';
-
 import withUserId from '@hocs/withUserId';
 
-function App() {
+function AppComponent() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
@@ -30,4 +29,6 @@ function App() {
   );
 }
 
-export default withUserId(App);
+const App = withUserId(AppComponent);
+
+export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,14 +5,18 @@ import { MainPage, ClientPage, HostPage } from './pages';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@apis/index';
 
+import withUserId from '@hocs/withUserId';
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
-        <Router future={{ 
-          v7_startTransition: true,
-          v7_relativeSplatPath: true 
-        }}>
+        <Router
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true
+          }}
+        >
           <Routes>
             <Route path="/" element={<MainPage />} />
             <Route path="/live" element={<ClientPage />} />
@@ -26,4 +30,4 @@ function App() {
   );
 }
 
-export default App;
+export default withUserId(App);

--- a/frontend/src/apis/fetchBroadcastStatus.ts
+++ b/frontend/src/apis/fetchBroadcastStatus.ts
@@ -1,13 +1,10 @@
-import { getSessionKey } from '@utils/streamKey';
 import { fetchInstance } from '.';
 
 export type BroadcastStatusResponse = {
   state: boolean;
 };
 
-export const fetchBroadcastStatus = async (): Promise<BroadcastStatusResponse> => {
-  const sessionKey = getSessionKey();
-
+export const fetchBroadcastStatus = async (sessionKey: string): Promise<BroadcastStatusResponse> => {
   const response = await fetchInstance().get<BroadcastStatusResponse>('/host/state', {
     params: {
       sessionKey

--- a/frontend/src/apis/queries/host/useBroadcastStatusPolling.ts
+++ b/frontend/src/apis/queries/host/useBroadcastStatusPolling.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchBroadcastStatus } from '@apis/fetchBroadcastStatus';
 
-export const useBroadcastStatusPolling = (pollingInterVal = 10000) => {
+export const useBroadcastStatusPolling = (sessionKey: string, pollingInterVal = 10000) => {
   return useQuery({
-    queryKey: ['broadcastState'],
-    queryFn: fetchBroadcastStatus,
+    queryKey: ['broadcastState', sessionKey],
+    queryFn: () => fetchBroadcastStatus(sessionKey),
     refetchInterval: pollingInterVal,
     refetchIntervalInBackground: true,
     refetchOnWindowFocus: true,

--- a/frontend/src/components/host/Setting.tsx
+++ b/frontend/src/components/host/Setting.tsx
@@ -2,9 +2,10 @@ import styled from 'styled-components';
 import Player from './Player';
 import SettingForm from './SettingForm';
 import { useBroadcastStatusPolling } from '@apis/queries/host/useBroadcastStatusPolling';
+import { getSessionKey } from '@utils/streamKey';
 
 export default function Setting() {
-  const { data: onStreaming } = useBroadcastStatusPolling();
+  const { data: onStreaming } = useBroadcastStatusPolling(getSessionKey());
 
   return (
     <Container>

--- a/frontend/src/components/host/SettingInfo.tsx
+++ b/frontend/src/components/host/SettingInfo.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import OBSIcon from '@assets/img_studio_obs.png';
 import DownloadIcon from '@assets/download.svg';
-import { getOrCreateId } from '@utils/id';
+import { getStoredId } from '@utils/id';
 import useFetchStreamKey from '@apis/queries/host/useFetchStreamKey';
 import { useEffect } from 'react';
 import { setSessionKey, setStreamKey } from '@utils/streamKey';
@@ -11,7 +11,7 @@ interface SettingInfoProps {
 }
 
 export default function SettingInfo({ closeModal }: SettingInfoProps) {
-  const userId = getOrCreateId();
+  const userId = getStoredId();
   const { mutate: fetchKey, data } = useFetchStreamKey({
     onSuccess: ({ streamKey, sessionKey }) => {
       setStreamKey(streamKey);

--- a/frontend/src/hocs/withUserId.tsx
+++ b/frontend/src/hocs/withUserId.tsx
@@ -1,0 +1,8 @@
+import { getOrCreateId } from '@utils/id';
+
+export default function withUserId(WrappedComponent: React.ComponentType) {
+  return function WithUserIdComponent(props: any) {
+    getOrCreateId();
+    return <WrappedComponent {...props} />;
+  };
+}

--- a/frontend/src/hocs/withUserId.tsx
+++ b/frontend/src/hocs/withUserId.tsx
@@ -1,7 +1,8 @@
+import { ComponentType } from 'react';
 import { initializeUserId } from '@utils/id';
 
-export default function withUserId(WrappedComponent: React.ComponentType) {
-  return function WithUserIdComponent(props: any) {
+export default function withUserId<P extends object>(WrappedComponent: ComponentType<P>) {
+  return function WithUserIdComponent(props: P) {
     initializeUserId();
     return <WrappedComponent {...props} />;
   };

--- a/frontend/src/hocs/withUserId.tsx
+++ b/frontend/src/hocs/withUserId.tsx
@@ -1,8 +1,8 @@
-import { getOrCreateId } from '@utils/id';
+import { initializeUserId } from '@utils/id';
 
 export default function withUserId(WrappedComponent: React.ComponentType) {
   return function WithUserIdComponent(props: any) {
-    getOrCreateId();
+    initializeUserId();
     return <WrappedComponent {...props} />;
   };
 }

--- a/frontend/src/utils/id.ts
+++ b/frontend/src/utils/id.ts
@@ -1,11 +1,11 @@
 import { nanoid } from 'nanoid';
 
-const USER_ID_KEY = 'userId';
+const USER_ID_KEY = 'userId' as const;
 
-export const getStoredId = () => localStorage.getItem(USER_ID_KEY) ?? '';
+export const getStoredId = (): string => localStorage.getItem(USER_ID_KEY) ?? '';
 export const setStoredId = (id: string): void => localStorage.setItem(USER_ID_KEY, id);
 
-export const getOrCreateId = () => {
+export const getOrCreateId = (): string => {
   const savedId = getStoredId();
   if (savedId) return savedId;
 

--- a/frontend/src/utils/id.ts
+++ b/frontend/src/utils/id.ts
@@ -5,11 +5,10 @@ const USER_ID_KEY = 'userId' as const;
 export const getStoredId = (): string => localStorage.getItem(USER_ID_KEY) ?? '';
 export const setStoredId = (id: string): void => localStorage.setItem(USER_ID_KEY, id);
 
-export const getOrCreateId = (): string => {
+export const initializeUserId = () => {
   const savedId = getStoredId();
-  if (savedId) return savedId;
-
-  const newId = nanoid();
-  setStoredId(newId);
-  return newId;
+  if (!savedId) {
+    const newId = nanoid();
+    setStoredId(newId);
+  }
 };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,7 +19,8 @@
       "@styles/*": ["src/styles/*"],
       "@type/*": ["src/type/*"],
       "@apis/*": ["src/apis/*"],
-      "@queries/*": ["src/apis/queries/*"]
+      "@queries/*": ["src/apis/queries/*"],
+      "@hocs/*": ["src/hocs/*"]
     },
     "types": ["vite/client"]
   },


### PR DESCRIPTION
## 🚀 Issue Number
- resolve: #147 

## 주요 작업
<!-- 문제 상황 정의 -->
로그인을 구현하지 않습니다. 그래서 user를 식별할 수 있는 nanoId를 페이지 전역에서 확인하고 로컬에 저장합니다.
해당 기능을 고차 컴포넌트로 구현하여 관심사를 분리했습닏.

## 고민과 해결 과정
<!-- 변경 사항 -->
HOC 폴더 생성
전역에서 id를 생성하기 때문에, 기존 유틸 함수명이였던 `getOrCreateId` 에서 `initializeUserId`로 변경했습니다.
추가로 id 유틸에 있던 세션키 로직이 api 내부에서 호출하여 동작했습니다. 순수 함수로 전환을 위해 키를 파라미터로 주입하는 방향으로 변경했습니다.


## 📸 Screenshots


## 🔜 추가 내용 (선택)
