### PR TITLE
[FEAT] 미리보기 파일 추가 시 수정 삭제 버튼 구현

### DIFF
--- a/frontend/src/utils/convertToBase64.ts
+++ b/frontend/src/utils/convertToBase64.ts
@@ -1,0 +1,14 @@
+export const convertToBase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+      } else {
+        reject(new Error('Failed to convert image to base64'));
+      }
+    };
+    reader.onerror = (error) => reject(error);
+    reader.readAsDataURL(file);
+  });
+};


### PR DESCRIPTION
## 🚀 Issue Number
- resolve: #150 

## 주요 작업
<!-- 문제 상황 정의 -->
미리보기 이미지 업로드 시 수정 삭제할 수 있는 버튼 기능 구현

## 고민과 해결 과정

고민: 최초 삭제 버튼 클릭 시, 리액트의 status에는 값이 사라졌습니다. 하지만 input value는 그대로여서 다시 같은 인풋 요소를 추가했을 때 미리보기에 변화가 없었습니다.

해결 : input을 Ref로 관리하여 삭제 버튼 클릭 시 input value를 초기화 했습니다.


### 추후 계획
host 페이지의 상태와 컴포넌트들이 많아지고 있습니다. 추후 이미지 인풋, 태그와 같이 덩어리 있는 컴포넌트들은 별도 분리 예정입니다.


## 📸 Screenshots
![Nov-20-2024 16-55-27](https://github.com/user-attachments/assets/8bd11675-e24d-4851-9c17-e44f96dc2914)


## 🔜 추가 내용 (선택)
