### PR TITLE
[FEAT] 메인페이지에서 라이브 영상 재생

### DIFF
--- a/frontend/src/apis/fetchMainLive.ts
+++ b/frontend/src/apis/fetchMainLive.ts
@@ -1,21 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { fetchInstance } from '.';
-
-type ChannelInfo = {
-  channelId: string | null;
-  channelName: string;
-};
-
-export type MainLive = {
-  id: number;
-  liveId: string;
-  liveTitle: string;
-  liveImageUrl: string;
-  category: string;
-  defaultThumbnailImageUrl: string;
-  concurrentUserCount: number;
-  channel: ChannelInfo;
-};
+import { MainLive } from '@type/live';
 
 type MainLiveResponse = {
   info: MainLive[];

--- a/frontend/src/apis/fetchRecentLive.ts
+++ b/frontend/src/apis/fetchRecentLive.ts
@@ -1,0 +1,13 @@
+import { AxiosResponse } from 'axios';
+import { fetchInstance } from '.';
+import { RecentLive } from '@type/live';
+
+type RecentLiveResponse = {
+  info: RecentLive[];
+};
+
+export const fetchRecentLive = async (): Promise<RecentLive[]> => {
+  const response: AxiosResponse<RecentLiveResponse> = await fetchInstance().get('/streams/live');
+
+  return response.data.info;
+};

--- a/frontend/src/apis/queries/main/useFetchMainLive.ts
+++ b/frontend/src/apis/queries/main/useFetchMainLive.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchMainLive, MainLive } from '@apis/fetchMainLive';
+
+import { fetchMainLive } from '@apis/fetchMainLive';
+import { MainLive } from '@type/live';
 
 export const useMainLive = () => {
   return useQuery<MainLive[], Error>({

--- a/frontend/src/apis/queries/main/useFetchRecentLive.ts
+++ b/frontend/src/apis/queries/main/useFetchRecentLive.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchRecentLive } from '@apis/fetchRecentLive';
+import { RecentLive } from '@type/live';
+
+export const useRecentLive = () => {
+  return useQuery<RecentLive[], Error>({
+    queryKey: ['recentLive'],
+    queryFn: fetchRecentLive,
+    refetchOnWindowFocus: false
+  });
+};

--- a/frontend/src/components/client/ClientView.tsx
+++ b/frontend/src/components/client/ClientView.tsx
@@ -1,14 +1,17 @@
 import styled from 'styled-components';
+import { useParams } from 'react-router-dom';
 
 import Player from './Player';
 import PlayerInfo from './PlayerInfo';
 import Footer from './Footer';
 
 const ClientView = () => {
+  const { id: liveId } = useParams();
+
   return (
     <ClientViewContainer>
       <h1 className="hidden">클라이언트 페이지</h1>
-      <Player videoUrl={'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8'} />
+      <Player videoUrl={`https://kr.object.ncloudstorage.com/web22/live/${liveId}/index.m3u8`} />
       <PlayerInfo />
       <Footer />
     </ClientViewContainer>

--- a/frontend/src/components/main/LiveVideoCard.tsx
+++ b/frontend/src/components/main/LiveVideoCard.tsx
@@ -33,7 +33,7 @@ const LiveVideoCard = ({ videoData }: LiveVideoCardProps) => {
 
       <VideoCardWrapper>
         <VideoCardProfile>
-        <img src={sampleProfile} />
+          <img src={sampleProfile} />
         </VideoCardProfile>
         <VideoCardArea>
           <span className="video_card_title" style={{ cursor: 'pointer' }} onClick={handleLiveClick}>

--- a/frontend/src/components/main/LiveVideoCard.tsx
+++ b/frontend/src/components/main/LiveVideoCard.tsx
@@ -2,16 +2,16 @@ import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
 import sampleThumbnail from '@assets/sampleThumbnail.png';
+import sampleProfile from '@assets/sample_profile.png';
 import { RecentLive } from '@type/live';
-import { LiveBadge, LiveViewCountBadge, ReplayBadge, ReplayViewCountBadge } from './ThumbnailBadge';
+import { LiveBadge, LiveViewCountBadge } from './ThumbnailBadge';
 import ShowInfoBadge from './ShowInfoBadge';
 
-interface VideoCardProps {
-  type: 'live' | 'replay';
+interface LiveVideoCardProps {
   videoData: RecentLive;
 }
 
-const VideoCard = ({ type, videoData }: VideoCardProps) => {
+const LiveVideoCard = ({ videoData }: LiveVideoCardProps) => {
   const navigate = useNavigate();
 
   const { concurrentUserCount, category, channel, tags, defaultThumbnailImageUrl, liveId, liveImageUrl, liveTitle } =
@@ -25,21 +25,16 @@ const VideoCard = ({ type, videoData }: VideoCardProps) => {
     <VideoCardContainer>
       <VideoCardThumbnail onClick={handleLiveClick}>
         <VideoCardImage src={defaultThumbnailImageUrl ?? liveImageUrl} />
-        {type === 'live' ? (
-          <VideoCardDescription>
-            <LiveBadge />
-            <LiveViewCountBadge count={concurrentUserCount} />
-          </VideoCardDescription>
-        ) : (
-          <VideoCardDescription>
-            <ReplayBadge />
-            <ReplayViewCountBadge count={1125} />
-          </VideoCardDescription>
-        )}
+        <VideoCardDescription>
+          <LiveBadge />
+          <LiveViewCountBadge count={concurrentUserCount} />
+        </VideoCardDescription>
       </VideoCardThumbnail>
 
       <VideoCardWrapper>
-        <VideoCardProfile></VideoCardProfile>
+        <VideoCardProfile>
+        <img src={sampleProfile} />
+        </VideoCardProfile>
         <VideoCardArea>
           <span className="video_card_title" style={{ cursor: 'pointer' }} onClick={handleLiveClick}>
             {liveTitle}
@@ -57,7 +52,7 @@ const VideoCard = ({ type, videoData }: VideoCardProps) => {
   );
 };
 
-export default VideoCard;
+export default LiveVideoCard;
 
 const VideoCardContainer = styled.div`
   word-wrap: break-word;

--- a/frontend/src/components/main/MainLiveSection.tsx
+++ b/frontend/src/components/main/MainLiveSection.tsx
@@ -1,23 +1,36 @@
 import styled from 'styled-components';
+
 import VideoCard from './VideoCard';
 import LoadMoreDivider from './LoadMoreDivider';
+import { useRecentLive } from '@apis/queries/main/useFetchRecentLive';
 
 interface MainLiveSectionProps {
   title: string;
   type: 'live' | 'replay';
 }
 const MainLiveSection = ({ title, type }: MainLiveSectionProps) => {
+  // TODO: 다시보기가 만들어지면 useRecentReplay 삼항연산자로 변경
+  const { data = [], isLoading, error } = useRecentLive();
+
   return (
     <MainSectionContainer>
       <MainSectionHeader>
         <p className="live_section_title">{title}</p>
         <button className="live_section_button">전체보기</button>
       </MainSectionHeader>
-      <MainSectionContentList>
-        {[1, 2, 3, 4, 5, 6].map((_, index) => (
-          <VideoCard key={index} type={type} />
-        ))}
-      </MainSectionContentList>
+
+      {isLoading && <div>로딩 중...</div>}
+
+      {data.length === 0 && !isLoading && <div>데이터가 없습니다.</div>}
+
+      {data.length !== 0 && (
+        <MainSectionContentList>
+          {data.map((video) => (
+            <VideoCard key={video.id} type={type} videoData={video} />
+          ))}
+        </MainSectionContentList>
+      )}
+
       <LoadMoreDivider text="더보기" />
       <div className="parent">
         <div className="child"></div>

--- a/frontend/src/components/main/MainLiveSection.tsx
+++ b/frontend/src/components/main/MainLiveSection.tsx
@@ -13,6 +13,10 @@ const MainLiveSection = ({ title, type }: MainLiveSectionProps) => {
   // TODO: 다시보기가 만들어지면 useRecentReplay 삼항연산자로 변경
   const { data = [], isLoading, error } = useRecentLive();
 
+  if (error) {
+    return <div>데이터를 가져오는 중 에러가 발생했습니다.</div>;
+  }
+
   return (
     <MainSectionContainer>
       <MainSectionHeader>

--- a/frontend/src/components/main/MainLiveSection.tsx
+++ b/frontend/src/components/main/MainLiveSection.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
-import VideoCard from './VideoCard';
+import ReplayVideoCard from './ReplayVideoCard';
+import LiveVideoCard from './LiveVideoCard';
 import LoadMoreDivider from './LoadMoreDivider';
 import { useRecentLive } from '@apis/queries/main/useFetchRecentLive';
 
@@ -23,10 +24,16 @@ const MainLiveSection = ({ title, type }: MainLiveSectionProps) => {
 
       {data.length === 0 && !isLoading && <div>데이터가 없습니다.</div>}
 
-      {data.length !== 0 && (
+      {type === 'live' ? (
         <MainSectionContentList>
           {data.map((video) => (
-            <VideoCard key={video.id} type={type} videoData={video} />
+            <LiveVideoCard key={video.id} videoData={video} />
+          ))}
+        </MainSectionContentList>
+      ) : (
+        <MainSectionContentList>
+          {data.map((video) => (
+            <ReplayVideoCard key={video.id} videoData={video} />
           ))}
         </MainSectionContentList>
       )}

--- a/frontend/src/components/main/RecommendLive.tsx
+++ b/frontend/src/components/main/RecommendLive.tsx
@@ -156,7 +156,8 @@ const RecommendLiveProfile = styled.div`
   height: 70px;
 
   &:hover {
-    border: 4px solid ${({ theme }) => theme.tokenColors['brand-default']};
+    outline: 4px solid ${({ theme }) => theme.tokenColors['brand-default']};
+    outline-offset: -2px;
   }
 
   img {

--- a/frontend/src/components/main/RecommendLive.tsx
+++ b/frontend/src/components/main/RecommendLive.tsx
@@ -12,8 +12,6 @@ const RecommendLive = () => {
   const { data: mainLiveData, isLoading, error } = useMainLive();
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
-  // const videoUrl = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
-
   useEffect(() => {
     if (!mainLiveData || mainLiveData.length === 0) return;
 

--- a/frontend/src/components/main/RecommendLive.tsx
+++ b/frontend/src/components/main/RecommendLive.tsx
@@ -12,8 +12,7 @@ const RecommendLive = () => {
   const { data: mainLiveData, isLoading, error } = useMainLive();
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
-  // const videoUrl = `https://kr.object.ncloudstorage.com/web22/live/${liveData.liveId}/index.m3u8`;
-  const videoUrl = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
+  // const videoUrl = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
 
   useEffect(() => {
     if (!mainLiveData || mainLiveData.length === 0) return;
@@ -34,7 +33,7 @@ const RecommendLive = () => {
       videoElement.src = videoUrl;
       videoElement.play();
     }
-  }, [mainLiveData, videoUrl]);
+  }, [mainLiveData]);
 
   if (error) {
     return <div>데이터를 가져오는 중 에러가 발생했습니다.</div>;
@@ -46,6 +45,7 @@ const RecommendLive = () => {
 
   const liveData = mainLiveData[0];
   const { liveId, liveTitle, concurrentUserCount, channel, category } = liveData;
+  const videoUrl = `https://kr.object.ncloudstorage.com/web22/live/${liveId}/index.m3u8`;
 
   return (
     <RecommendLiveContainer>

--- a/frontend/src/components/main/ReplayVideoCard.tsx
+++ b/frontend/src/components/main/ReplayVideoCard.tsx
@@ -1,0 +1,130 @@
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+import sampleThumbnail from '@assets/sampleThumbnail.png';
+import sampleProfile from '@assets/sample_profile.png';
+import { RecentLive } from '@type/live';
+import { ReplayBadge, ReplayViewCountBadge } from './ThumbnailBadge';
+import ShowInfoBadge from './ShowInfoBadge';
+
+interface ReplayVideoCardProps {
+  videoData: RecentLive;
+}
+
+const ReplayVideoCard = ({ videoData }: ReplayVideoCardProps) => {
+  const navigate = useNavigate();
+
+  const { concurrentUserCount, category, channel, tags, defaultThumbnailImageUrl, liveId, liveImageUrl, liveTitle } =
+    videoData;
+
+  const handleLiveClick = () => {
+    navigate(`/live/${liveId}`);
+  };
+
+  return (
+    <VideoCardContainer>
+      <VideoCardThumbnail onClick={handleLiveClick}>
+        <VideoCardImage src={defaultThumbnailImageUrl ?? liveImageUrl} />
+        <VideoCardDescription>
+          <ReplayBadge />
+          <ReplayViewCountBadge count={concurrentUserCount} />
+        </VideoCardDescription>
+      </VideoCardThumbnail>
+
+      <VideoCardWrapper>
+        <VideoCardProfile>
+          <img src={sampleProfile} />
+        </VideoCardProfile>
+        <VideoCardArea>
+          <span className="video_card_title" style={{ cursor: 'pointer' }} onClick={handleLiveClick}>
+            {liveTitle}
+          </span>
+          <span className="video_card_name">{channel.channelName}</span>
+          <VideoCardInformation>
+            <ShowInfoBadge badgeType="category" text={category} />
+            {tags.map((tag, index) => (
+              <ShowInfoBadge key={index} badgeType="tag" text={tag} />
+            ))}
+          </VideoCardInformation>
+        </VideoCardArea>
+      </VideoCardWrapper>
+    </VideoCardContainer>
+  );
+};
+
+export default ReplayVideoCard;
+
+const VideoCardContainer = styled.div`
+  word-wrap: break-word;
+  word-break: break-all;
+`;
+
+const VideoCardThumbnail = styled.div`
+  background: #21242a url(${sampleThumbnail}) no-repeat center center / cover;
+  overflow: hidden;
+  border-radius: 12px;
+  display: block;
+  padding-top: 56.25%;
+  position: relative;
+  cursor: pointer;
+`;
+
+const VideoCardImage = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const VideoCardDescription = styled.div`
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  display: flex;
+`;
+
+const VideoCardWrapper = styled.div`
+  margin-top: 12px;
+  display: flex;
+  min-width: 0;
+`;
+
+const VideoCardProfile = styled.div`
+  margin-right: 10px;
+  background: ${({ theme }) => theme.tokenColors['surface-alt']} no-repeat 50% / cover;
+  border-radius: 50%;
+  display: block;
+  overflow: hidden;
+  width: 40px;
+  height: 40px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+const VideoCardArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 5px;
+  .video_card_title {
+    ${({ theme }) => theme.tokenTypographys['display-bold16']}
+    color: ${({ theme }) => theme.tokenColors['text-strong']};
+    margin-bottom: 8px;
+  }
+  .video_card_name {
+    ${({ theme }) => theme.tokenTypographys['display-medium14']}
+    color: ${({ theme }) => theme.tokenColors['text-bold']};
+    margin-bottom: 6px;
+  }
+`;
+
+const VideoCardInformation = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+`;

--- a/frontend/src/components/main/VideoCard.tsx
+++ b/frontend/src/components/main/VideoCard.tsx
@@ -1,21 +1,34 @@
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
 import sampleThumbnail from '@assets/sampleThumbnail.png';
+import { RecentLive } from '@type/live';
 import { LiveBadge, LiveViewCountBadge, ReplayBadge, ReplayViewCountBadge } from './ThumbnailBadge';
 import ShowInfoBadge from './ShowInfoBadge';
 
 interface VideoCardProps {
   type: 'live' | 'replay';
+  videoData: RecentLive;
 }
 
-const VideoCard = ({ type }: VideoCardProps) => {
+const VideoCard = ({ type, videoData }: VideoCardProps) => {
+  const navigate = useNavigate();
+
+  const { concurrentUserCount, category, channel, tags, defaultThumbnailImageUrl, liveId, liveImageUrl, liveTitle } =
+    videoData;
+
+  const handleLiveClick = () => {
+    navigate(`/live/${liveId}`);
+  };
+
   return (
     <VideoCardContainer>
-      <VideoCardThumbnail>
-        <VideoCardImage src={sampleThumbnail} />
+      <VideoCardThumbnail onClick={handleLiveClick}>
+        <VideoCardImage src={defaultThumbnailImageUrl ?? liveImageUrl} />
         {type === 'live' ? (
           <VideoCardDescription>
             <LiveBadge />
-            <LiveViewCountBadge count={1125} />
+            <LiveViewCountBadge count={concurrentUserCount} />
           </VideoCardDescription>
         ) : (
           <VideoCardDescription>
@@ -28,11 +41,15 @@ const VideoCard = ({ type }: VideoCardProps) => {
       <VideoCardWrapper>
         <VideoCardProfile></VideoCardProfile>
         <VideoCardArea>
-          <span className="video_card_title">방송 제목 방송 제목</span>
-          <span className="video_card_name">라이부</span>
+          <span className="video_card_title" style={{ cursor: 'pointer' }} onClick={handleLiveClick}>
+            {liveTitle}
+          </span>
+          <span className="video_card_name">{channel.channelName}</span>
           <VideoCardInformation>
-            <ShowInfoBadge badgeType="category" text="프론트엔드" />
-            <ShowInfoBadge badgeType="tag" text="태그" />
+            <ShowInfoBadge badgeType="category" text={category} />
+            {tags.map((tag, index) => (
+              <ShowInfoBadge key={index} badgeType="tag" text={tag} />
+            ))}
           </VideoCardInformation>
         </VideoCardArea>
       </VideoCardWrapper>
@@ -54,6 +71,7 @@ const VideoCardThumbnail = styled.div`
   display: block;
   padding-top: 56.25%;
   position: relative;
+  cursor: pointer;
 `;
 
 const VideoCardImage = styled.img`

--- a/frontend/src/type/live.ts
+++ b/frontend/src/type/live.ts
@@ -1,0 +1,19 @@
+type ChannelInfo = {
+  channelId: string | null;
+  channelName: string;
+};
+
+export interface MainLive {
+  id: number;
+  liveId: string;
+  liveTitle: string;
+  liveImageUrl: string;
+  category: string;
+  defaultThumbnailImageUrl: string;
+  concurrentUserCount: number;
+  channel: ChannelInfo;
+}
+
+export interface RecentLive extends MainLive {
+  tags: string[];
+}


### PR DESCRIPTION
## 🚀 Issue Number
resolve: #117 

## 주요 작업
- 메인페이지
    - 메인페이지의 메인 라이브영상에서 프로필 hover시 outline 추가
    - 라이브영상과 다시보기 영상 video 컴포넌트 2가지로 분리 (다시보기 video 컴포넌트는 아직 미작업)
    - 메인페이지의 메인 라이브영상 실제 주소로 변경
- 클라이언트 페이지
    - useParam으로 id값으로 목데이터 제거하고 실제영상으로 대체


## 고민과 해결 과정
- main/video컴포넌트에서 다른 API를 어떻게 관리할지 고민했고 분리하는 결정을 했습니다.

## 📸 Screenshots
![image](https://github.com/user-attachments/assets/756eb72c-d237-4af3-bca5-2517068f672e)

## 🔜 추가 내용 (선택)
