### PR TITLE
[FIX] 세션 키 최신화하여 api 요청

### DIFF
--- a/frontend/src/components/host/Setting.tsx
+++ b/frontend/src/components/host/Setting.tsx
@@ -3,9 +3,23 @@ import Player from './Player';
 import SettingForm from './SettingForm';
 import { useBroadcastStatusPolling } from '@apis/queries/host/useBroadcastStatusPolling';
 import { getSessionKey } from '@utils/streamKey';
+import { useEffect, useState } from 'react';
 
 export default function Setting() {
-  const { data: onStreaming } = useBroadcastStatusPolling(getSessionKey());
+  const [sessionKey, setSessionKey] = useState(getSessionKey());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const currentKey = getSessionKey();
+      if (currentKey !== sessionKey) {
+        setSessionKey(currentKey);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [sessionKey]);
+
+  const { data: onStreaming } = useBroadcastStatusPolling(sessionKey);
 
   return (
     <Container>


### PR DESCRIPTION
## 🚀 Issue Number
- resolve: #186 

## 주요 작업
<!-- 문제 상황 정의 -->
최초 호스트 페이지 진입 시 session key가 없는 상태로 api를 호출했습니다.
모달을 열 때 세션키가 등록 되지만, 등록된 후에도 api 함수에 세션키가 고정되어 빈값을 전송했습니다.
useState와 useEffect로 세션키를 감지하여 변경 시 업데이트하고, 새로운 키를 api에 주입하는 형태로 변경하였습니다.

## 고민과 해결 과정
<!-- 변경 사항 -->


## 📸 Screenshots


## 🔜 추가 내용 (선택)
