### PR TITLE
[FEAT] 영상 세그먼트 키프레임 고정 및 다시보기 영상 최신/단일 데이터 API 작성

### DIFF
--- a/backend/mainServer/src/app.module.ts
+++ b/backend/mainServer/src/app.module.ts
@@ -5,9 +5,10 @@ import { HostModule } from './host/host.module.js';
 import { StreamsModule } from './streams/streams.module.js';
 import { MockDataModule } from './mock-data/mock-data.module.js';
 import { MemoryDBModule } from './memory-db/memory-db.module.js';
+import { ReplayModule } from './replay/replay.module.js';
 
 @Module({
-  imports: [HostModule, StreamsModule, MockDataModule, MemoryDBModule],
+  imports: [HostModule, StreamsModule, MockDataModule, MemoryDBModule, ReplayModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/mainServer/src/app.module.ts
+++ b/backend/mainServer/src/app.module.ts
@@ -8,7 +8,7 @@ import { MemoryDBModule } from './memory-db/memory-db.module.js';
 import { ReplayModule } from './replay/replay.module.js';
 
 @Module({
-  imports: [HostModule, StreamsModule, MockDataModule, MemoryDBModule, ReplayModule],
+  imports: [MemoryDBModule, HostModule, StreamsModule, ReplayModule, MockDataModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/mainServer/src/common/constants.ts
+++ b/backend/mainServer/src/common/constants.ts
@@ -3,3 +3,5 @@ export const DEFAULT_VALUE = {
   NOTICE : '쾌적한 컨퍼런스 환경을 위해 상대방을 존중하는 언어를 사용해 주시길 바랍니다. 모두가 배움과 소통을 즐길 수 있는 문화를 함께 만들기에 동참해주세요.',
   HOST_NAME : '방송 진행자',
 };
+
+export const REPLAY_VIDEO_LATENCY = 7;

--- a/backend/mainServer/src/common/transformers.ts
+++ b/backend/mainServer/src/common/transformers.ts
@@ -1,0 +1,24 @@
+import { MemoryDbDto } from '../dto/memoryDbDto';
+import { ReplayVideoDto } from '../dto/replayVideoDto';
+
+export function memoryDbDtoToReplayVideoDto(memoryDbDto: MemoryDbDto): ReplayVideoDto {
+  return {
+    videoNo: memoryDbDto.id,
+    videoId: memoryDbDto.sessionKey,
+    videoTitle: memoryDbDto.liveTitle,
+    publishDate: memoryDbDto.startDate || new Date(),
+    thumbnailImageUrl: memoryDbDto.defaultThumbnailImageUrl || memoryDbDto.liveImageUrl,
+    trailerUrl: memoryDbDto.liveImageUrl || null,
+    duration: memoryDbDto.endDate && memoryDbDto.startDate
+      ? Math.floor((memoryDbDto.endDate.getTime() - memoryDbDto.startDate.getTime()) / 1000)
+      : 0,
+    readCount: memoryDbDto.readCount || 0,
+    publishDateAt: memoryDbDto.startDate ? memoryDbDto.startDate.getTime() : undefined,
+    category: memoryDbDto.category || 'unknown',
+    livePr: memoryDbDto.livePr || 0,
+    channel: {
+      channelId: memoryDbDto.channel.channelId,
+      channelName: memoryDbDto.channel.channelName,
+    },
+  };
+}

--- a/backend/mainServer/src/common/transformers.ts
+++ b/backend/mainServer/src/common/transformers.ts
@@ -6,14 +6,14 @@ export function memoryDbDtoToReplayVideoDto(memoryDbDto: MemoryDbDto): ReplayVid
     videoNo: memoryDbDto.id,
     videoId: memoryDbDto.sessionKey,
     videoTitle: memoryDbDto.liveTitle,
-    publishDate: memoryDbDto.startDate || new Date(),
+    startDate: memoryDbDto.startDate || new Date(),
+    endDate: memoryDbDto.endDate || new Date(),
     thumbnailImageUrl: memoryDbDto.defaultThumbnailImageUrl || memoryDbDto.liveImageUrl,
     trailerUrl: memoryDbDto.liveImageUrl || null,
     duration: memoryDbDto.endDate && memoryDbDto.startDate
       ? Math.floor((memoryDbDto.endDate.getTime() - memoryDbDto.startDate.getTime()) / 1000)
       : 0,
     readCount: memoryDbDto.readCount || 0,
-    publishDateAt: memoryDbDto.startDate ? memoryDbDto.startDate.getTime() : undefined,
     category: memoryDbDto.category || 'unknown',
     tags: memoryDbDto.tags || [],
     livePr: memoryDbDto.livePr || 0,

--- a/backend/mainServer/src/common/transformers.ts
+++ b/backend/mainServer/src/common/transformers.ts
@@ -15,6 +15,7 @@ export function memoryDbDtoToReplayVideoDto(memoryDbDto: MemoryDbDto): ReplayVid
     readCount: memoryDbDto.readCount || 0,
     publishDateAt: memoryDbDto.startDate ? memoryDbDto.startDate.getTime() : undefined,
     category: memoryDbDto.category || 'unknown',
+    tags: memoryDbDto.tags || [],
     livePr: memoryDbDto.livePr || 0,
     channel: {
       channelId: memoryDbDto.channel.channelId,

--- a/backend/mainServer/src/common/util.ts
+++ b/backend/mainServer/src/common/util.ts
@@ -40,3 +40,25 @@ export function randomKey(uuid: string, salt: string, length: number = 20) {
   const hash = crypto.createHmac('sha256', salt).update(uuid).digest('hex');
   return hash.substring(0, length);
 }
+
+export function generatePlaylist(N: number): string {
+  const header = `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:2
+#EXT-X-MEDIA-SEQUENCE:0`;
+
+  const body = Array.from({ length: N + 1 }, (_, i) => {
+    const duration = 2.000000;
+    return `#EXTINF:${duration.toFixed(6)},
+index${i}.ts`;
+  }).join('\n');
+
+  const footer = `#EXT-X-ENDLIST`;
+
+  return `${header}\n${body}\n${footer}`;
+}
+
+export function calculateSecondsBetweenDates(date1: Date, date2: Date): number {
+  const timeDifference = Math.abs(date1.getTime() - date2.getTime());
+  return Math.floor(timeDifference / 1000);
+}

--- a/backend/mainServer/src/common/util.ts
+++ b/backend/mainServer/src/common/util.ts
@@ -53,7 +53,7 @@ export function generatePlaylist(N: number): string {
 index${i}.ts`;
   }).join('\n');
 
-  const footer = `#EXT-X-ENDLIST`;
+  const footer = '#EXT-X-ENDLIST';
 
   return `${header}\n${body}\n${footer}`;
 }

--- a/backend/mainServer/src/dto/memoryDbDto.ts
+++ b/backend/mainServer/src/dto/memoryDbDto.ts
@@ -1,8 +1,17 @@
 import { LiveVideoRequestDto } from './liveSessionDto.js';
 import { DEFAULT_VALUE } from '../common/constants.js';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ChannelDto {
+  @ApiProperty({
+    description: '(미사용)호스트 ID 문자열',
+    example: 'channel123',
+  })
   channelId: string = '';
+  @ApiProperty({
+    description: '호스트 이름',
+    example: 'booduck',
+  })
   channelName: string = '';
 }
 
@@ -26,6 +35,8 @@ export class MemoryDbDto {
   state : boolean = false;
   startDate : Date | null = null;
   endDate : Date | null = null;
+  readCount: number;
+  livePr: number;
 
   constructor(data?: Partial<MemoryDbDto>) {
     if (data) {

--- a/backend/mainServer/src/dto/memoryDbDto.ts
+++ b/backend/mainServer/src/dto/memoryDbDto.ts
@@ -7,12 +7,12 @@ export class ChannelDto {
     description: '(미사용)호스트 ID 문자열',
     example: 'channel123',
   })
-  channelId: string = '';
+    channelId: string = '';
   @ApiProperty({
     description: '호스트 이름',
     example: 'booduck',
   })
-  channelName: string = '';
+    channelName: string = '';
 }
 
 export class MemoryDbDto {
@@ -33,10 +33,11 @@ export class MemoryDbDto {
   category: string = '';
   tags: Array<string> = [];
   state : boolean = false;
+  replay: boolean = false;
   startDate : Date | null = null;
   endDate : Date | null = null;
-  readCount: number;
-  livePr: number;
+  readCount: number = 0;
+  livePr: number = 0;
 
   constructor(data?: Partial<MemoryDbDto>) {
     if (data) {

--- a/backend/mainServer/src/dto/replayVideoDto.ts
+++ b/backend/mainServer/src/dto/replayVideoDto.ts
@@ -6,74 +6,89 @@ export class ReplayVideoDto {
     description: '방송 고유 번호',
     example: 1,
   })
-  videoNo: number;
+    videoNo: number;
 
   @ApiProperty({
     description: '방송 ID(방송 세션키)',
     example: 'replay_session',
   })
-  videoId: string;
+    videoId: string;
 
   @ApiProperty({
     description: '방송 제목',
     example: '재미있는 코딩 강의',
   })
-  videoTitle: string;
+    videoTitle: string;
 
   @ApiProperty({
     description: '방송 게시 날짜',
     example: '2024-11-25T10:00:00.000Z',
   })
-  publishDate: Date;
+    publishDate: Date;
 
   @ApiProperty({
     description: '썸네일 이미지 URL',
     example: 'https://kr.object.ncloudstorage.com/web22/static/liboo_default_thumbnail.png',
   })
-  thumbnailImageUrl: string;
+    thumbnailImageUrl: string;
 
   @ApiProperty({
     description: '트레일러 방송 URL',
     example: 'https://kr.object.ncloudstorage.com/web22/static/liboo_default_thumbnail.png',
     required: false,
   })
-  trailerUrl?: string;
+    trailerUrl?: string | null;
 
   @ApiProperty({
     description: '방송 재생 시간(초 단위)',
     example: 3600,
   })
-  duration: number;
+    duration: number;
 
   @ApiProperty({
     description: '조회수',
     example: 1000,
     required: false,
   })
-  readCount?: number;
+    readCount?: number;
 
   @ApiProperty({
     description: '게시 날짜의 타임스탬프',
     example: 1732400400000,
     required: false,
   })
-  publishDateAt?: number;
+    publishDateAt?: number;
 
   @ApiProperty({
     description: '방송 카테고리',
     example: 'education',
   })
-  category: string;
+    category: string;
 
   @ApiProperty({
     description: '라이브 조회수',
     example: 500,
   })
-  livePr: number;
+    livePr: number;
 
   @ApiProperty({
     description: '채널 정보',
     type: ChannelDto,
   })
-  channel: ChannelDto;
+    channel: ChannelDto;
+
+  constructor(init?: Partial<ReplayVideoDto>) {
+    this.videoNo = init?.videoNo ?? 0;
+    this.videoId = init?.videoId ?? '';
+    this.videoTitle = init?.videoTitle ?? '';
+    this.publishDate = init?.publishDate ?? new Date(0);
+    this.thumbnailImageUrl = init?.thumbnailImageUrl ?? '';
+    this.trailerUrl = init?.trailerUrl;
+    this.duration = init?.duration ?? 0;
+    this.readCount = init?.readCount;
+    this.publishDateAt = init?.publishDateAt;
+    this.category = init?.category ?? '';
+    this.livePr = init?.livePr ?? 0;
+    this.channel = init?.channel ?? new ChannelDto();
+  }
 }

--- a/backend/mainServer/src/dto/replayVideoDto.ts
+++ b/backend/mainServer/src/dto/replayVideoDto.ts
@@ -21,10 +21,17 @@ export class ReplayVideoDto {
     videoTitle: string;
 
   @ApiProperty({
-    description: '방송 게시 날짜',
+    description: '방송 시작 날짜',
     example: '2024-11-25T10:00:00.000Z',
   })
-    publishDate: Date;
+    startDate: Date;
+
+
+  @ApiProperty({
+    description: '방송 종료 날짜',
+    example: '2024-11-25T11:00:00.000Z',
+  })
+    endDate: Date;
 
   @ApiProperty({
     description: '썸네일 이미지 URL',
@@ -86,7 +93,8 @@ export class ReplayVideoDto {
     this.videoNo = init?.videoNo ?? 0;
     this.videoId = init?.videoId ?? '';
     this.videoTitle = init?.videoTitle ?? '';
-    this.publishDate = init?.publishDate ?? new Date(0);
+    this.startDate = init?.startDate ?? new Date(0);
+    this.endDate = init?.endDate ?? new Date(0);
     this.thumbnailImageUrl = init?.thumbnailImageUrl ?? '';
     this.trailerUrl = init?.trailerUrl;
     this.duration = init?.duration ?? 0;

--- a/backend/mainServer/src/dto/replayVideoDto.ts
+++ b/backend/mainServer/src/dto/replayVideoDto.ts
@@ -77,6 +77,11 @@ export class ReplayVideoDto {
   })
     channel: ChannelDto;
 
+  @ApiProperty({
+    description: '방송 태그',
+    example: ['tag1', 'tag2', 'tag3'],
+  })
+    tags: Array<string>;
   constructor(init?: Partial<ReplayVideoDto>) {
     this.videoNo = init?.videoNo ?? 0;
     this.videoId = init?.videoId ?? '';
@@ -90,5 +95,6 @@ export class ReplayVideoDto {
     this.category = init?.category ?? '';
     this.livePr = init?.livePr ?? 0;
     this.channel = init?.channel ?? new ChannelDto();
+    this.tags = init?.tags ?? [];
   }
 }

--- a/backend/mainServer/src/dto/replayVideoDto.ts
+++ b/backend/mainServer/src/dto/replayVideoDto.ts
@@ -1,0 +1,79 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ChannelDto } from './memoryDbDto.js';
+
+export class ReplayVideoDto {
+  @ApiProperty({
+    description: '방송 고유 번호',
+    example: 1,
+  })
+  videoNo: number;
+
+  @ApiProperty({
+    description: '방송 ID(방송 세션키)',
+    example: 'replay_session',
+  })
+  videoId: string;
+
+  @ApiProperty({
+    description: '방송 제목',
+    example: '재미있는 코딩 강의',
+  })
+  videoTitle: string;
+
+  @ApiProperty({
+    description: '방송 게시 날짜',
+    example: '2024-11-25T10:00:00.000Z',
+  })
+  publishDate: Date;
+
+  @ApiProperty({
+    description: '썸네일 이미지 URL',
+    example: 'https://kr.object.ncloudstorage.com/web22/static/liboo_default_thumbnail.png',
+  })
+  thumbnailImageUrl: string;
+
+  @ApiProperty({
+    description: '트레일러 방송 URL',
+    example: 'https://kr.object.ncloudstorage.com/web22/static/liboo_default_thumbnail.png',
+    required: false,
+  })
+  trailerUrl?: string;
+
+  @ApiProperty({
+    description: '방송 재생 시간(초 단위)',
+    example: 3600,
+  })
+  duration: number;
+
+  @ApiProperty({
+    description: '조회수',
+    example: 1000,
+    required: false,
+  })
+  readCount?: number;
+
+  @ApiProperty({
+    description: '게시 날짜의 타임스탬프',
+    example: 1732400400000,
+    required: false,
+  })
+  publishDateAt?: number;
+
+  @ApiProperty({
+    description: '방송 카테고리',
+    example: 'education',
+  })
+  category: string;
+
+  @ApiProperty({
+    description: '라이브 조회수',
+    example: 500,
+  })
+  livePr: number;
+
+  @ApiProperty({
+    description: '채널 정보',
+    type: ChannelDto,
+  })
+  channel: ChannelDto;
+}

--- a/backend/mainServer/src/host/host.controller.ts
+++ b/backend/mainServer/src/host/host.controller.ts
@@ -47,9 +47,7 @@ export class HostController {
   }
 
   @Get('/state')
-  @ApiOperation({
-    summary: 'Response this session is live", description: "현재 방송 세션이 라이브 상태인지 반환합니다.'
-  })
+  @ApiOperation({summary: 'Response this session is live', description: '현재 방송 세션이 라이브 상태인지 반환합니다.'})
   @ApiResponse({ status: 200, description: '현재 방송 상태에 대한 응답' })
   async getBroadcastState(@Query('sessionKey') sessionKey: string, @Res() res: Response) {
     const liveState = this.memoryDBService.findBySessionKey(sessionKey);

--- a/backend/mainServer/src/host/host.controller.ts
+++ b/backend/mainServer/src/host/host.controller.ts
@@ -145,9 +145,11 @@ export class HostController {
       }
       sessionInfo.state = false;
       sessionInfo.endDate = new Date();
-      const liveTime = calculateSecondsBetweenDates(sessionInfo.startDate, sessionInfo.endDate);
-      const m3u8Data = generatePlaylist(Math.floor(liveTime / 2));
-      this.hostService.uploadToS3(m3u8Data, sessionInfo.sessionKey, 'replay', 'm3u8');
+      if (sessionInfo.startDate) {
+        const liveTime = calculateSecondsBetweenDates(sessionInfo.startDate, sessionInfo.endDate);
+        const m3u8Data = generatePlaylist(Math.floor(liveTime / 2));
+        this.hostService.uploadToS3(m3u8Data, sessionInfo.sessionKey, 'replay', 'm3u8');
+      }
       this.memoryDBService.updateBySessionKey(streamKey, sessionInfo);
       res.status(HttpStatus.OK).send();
     } catch (error) {

--- a/backend/mainServer/src/host/host.controller.ts
+++ b/backend/mainServer/src/host/host.controller.ts
@@ -6,7 +6,7 @@ import { ApiCreatedResponse, ApiOperation, ApiResponse, ApiTags } from '@nestjs/
 import { MemoryDBService } from '../memory-db/memory-db.service.js';
 import { memoryDbDtoFromLiveVideoRequestDto } from '../dto/memoryDbDto.js';
 import { LiveVideoRequestDto } from '../dto/liveSessionDto.js';
-import { DEFAULT_VALUE } from '../common/constants.js';
+import { DEFAULT_VALUE, REPLAY_VIDEO_LATENCY } from '../common/constants.js';
 import { calculateSecondsBetweenDates, generatePlaylist } from '../common/util.js';
 
 @Controller('host')
@@ -147,7 +147,7 @@ export class HostController {
       sessionInfo.endDate = new Date();
       if (sessionInfo.startDate) {
         const liveTime = calculateSecondsBetweenDates(sessionInfo.startDate, sessionInfo.endDate);
-        const m3u8Data = generatePlaylist(Math.floor(liveTime / 2));
+        const m3u8Data = generatePlaylist(Math.floor(liveTime / 2) - REPLAY_VIDEO_LATENCY);
         this.hostService.uploadToS3(m3u8Data, sessionInfo.sessionKey, 'replay', 'm3u8');
       }
       this.memoryDBService.updateBySessionKey(streamKey, sessionInfo);

--- a/backend/mainServer/src/host/host.controller.ts
+++ b/backend/mainServer/src/host/host.controller.ts
@@ -7,6 +7,7 @@ import { MemoryDBService } from '../memory-db/memory-db.service.js';
 import { memoryDbDtoFromLiveVideoRequestDto } from '../dto/memoryDbDto.js';
 import { LiveVideoRequestDto } from '../dto/liveSessionDto.js';
 import { DEFAULT_VALUE } from '../common/constants.js';
+import { calculateSecondsBetweenDates, generatePlaylist } from '../common/util.js';
 
 @Controller('host')
 @ApiTags('Host API')
@@ -144,6 +145,9 @@ export class HostController {
       }
       sessionInfo.state = false;
       sessionInfo.endDate = new Date();
+      const liveTime = calculateSecondsBetweenDates(sessionInfo.startDate, sessionInfo.endDate);
+      const m3u8Data = generatePlaylist(Math.floor(liveTime / 2));
+      this.hostService.uploadToS3(m3u8Data, sessionInfo.sessionKey, 'replay', 'm3u8');
       this.memoryDBService.updateBySessionKey(streamKey, sessionInfo);
       res.status(HttpStatus.OK).send();
     } catch (error) {

--- a/backend/mainServer/src/host/host.service.ts
+++ b/backend/mainServer/src/host/host.service.ts
@@ -53,4 +53,29 @@ export class HostService {
       throw error;
     }
   }
+
+  async uploadToS3(data: string,  sessionKey: string, fileName: string, fileType: string = '') {
+    try {
+      const bucketName = process.env.OBJECT_STORAGE_BUCKET_NAME!;
+      const key = `live/${sessionKey}/${fileName}${fileType || '.' + fileType}`;
+      const params = {
+        Bucket: bucketName,
+        Key: key, 
+        Body: data,
+        ContentType: fileType,
+        ACL: 'public-read' as ObjectCannedACL
+      };
+
+      // PutObjectCommand로 파일 업로드
+      const command = new PutObjectCommand(params);
+      await s3Client.send(command);
+
+      // 업로드된 파일의 URL 반환
+      const location = `${process.env.OBJECT_STORAGE_ENDPOINT}/${bucketName}/${key}`;
+      return location;
+    } catch (error) {
+      console.error('Error uploading to S3:', error);
+      throw error;
+    }
+  }
 }

--- a/backend/mainServer/src/host/host.service.ts
+++ b/backend/mainServer/src/host/host.service.ts
@@ -57,7 +57,7 @@ export class HostService {
   async uploadToS3(data: string,  sessionKey: string, fileName: string, fileType: string = '') {
     try {
       const bucketName = process.env.OBJECT_STORAGE_BUCKET_NAME!;
-      const key = `live/${sessionKey}/${fileName}${fileType || '.' + fileType}`;
+      const key = `live/${sessionKey}/${fileName}.${fileType || fileType}`;
       const params = {
         Bucket: bucketName,
         Key: key, 

--- a/backend/mainServer/src/memory-db/memory-db.service.ts
+++ b/backend/mainServer/src/memory-db/memory-db.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { MemoryDbDto } from '../dto/memoryDbDto.js';
 import { getRandomElementsFromArray } from '../common/util.js';
-import { fromLiveSessionDto } from '../dto/liveSessionDto.js';
 
 @Injectable()
 export class MemoryDBService {
@@ -33,13 +32,13 @@ export class MemoryDBService {
     return getRandomElementsFromArray(liveSession, count);
   }
 
-  getBroadcastInfo(size: number) {
-    const liveSession = this.db.filter(item => item.state);
-    if (liveSession.length < size) {
-      const liveSessionRev = liveSession.reverse().map((info) => fromLiveSessionDto(info));
-      return [...liveSessionRev];
+  getBroadcastInfo<T>(size: number, dtoTransformer: (info: MemoryDbDto) => T, checker: (item: MemoryDbDto) => boolean) {
+    const findSession = this.db.filter(item => checker(item));
+    if (findSession.length < size) {
+      const findSessionRev = findSession.reverse().map((info) => dtoTransformer(info));
+      return [...findSessionRev];
     }
-    return liveSession.slice(-size).reverse().map((info) => fromLiveSessionDto(info));
+    return findSession.slice(-size).reverse().map((info) => dtoTransformer(info));
   }
 
   create(item: Partial<MemoryDbDto>): void {

--- a/backend/mainServer/src/memory-db/memory-db.service.ts
+++ b/backend/mainServer/src/memory-db/memory-db.service.ts
@@ -32,13 +32,24 @@ export class MemoryDBService {
     return getRandomElementsFromArray(liveSession, count);
   }
 
-  getBroadcastInfo<T>(size: number, dtoTransformer: (info: MemoryDbDto) => T, checker: (item: MemoryDbDto) => boolean) {
+  getBroadcastInfo<T>(size: number, dtoTransformer: (info: MemoryDbDto) => T, checker: (item: MemoryDbDto) => boolean, appender: number = 0) {
     const findSession = this.db.filter(item => checker(item));
     if (findSession.length < size) {
       const findSessionRev = findSession.reverse().map((info) => dtoTransformer(info));
-      return [...findSessionRev];
+      return [[...findSessionRev], []];
     }
-    return findSession.slice(-size).reverse().map((info) => dtoTransformer(info));
+    const latestSession = findSession.slice(-size).reverse().map((info) => dtoTransformer(info));
+    if (appender === 0) {
+      return [[...latestSession], []];
+    }
+    else if (findSession.length < size + appender) {
+      const appendSession = findSession.slice(0, findSession.length - size).reverse().map((info) => dtoTransformer(info));
+      return [[...latestSession], [...appendSession]];
+    }
+    else {
+      const appendSession = findSession.slice(-size - appender, -size).reverse().map((info) => dtoTransformer(info));
+      return [[...latestSession], [...appendSession]];
+    }
   }
 
   create(item: Partial<MemoryDbDto>): void {

--- a/backend/mainServer/src/mock-data/mock-data.service.ts
+++ b/backend/mainServer/src/mock-data/mock-data.service.ts
@@ -57,12 +57,115 @@ export class MockDataService implements OnModuleInit {
       }
     }),
     new MemoryDbDto({
+      userId: 'host004',
+      streamKey: 'stream004',
+      sessionKey: 'session004',
+      liveId: 'session004',
+      liveTitle: 'Music Live Show',
+      category: 'Music',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/test4_thumbnail.png',
+      tags: ['Music', 'Live', 'Concert'],
+      startDate: new Date('2024-11-21T19:00:00'),
+      endDate: new Date('2024-11-21T21:00:00'),
+      state: true,
+      channel: {
+        channelName: 'MNet',
+        channelId: '',
+      }
+    }),
+    new MemoryDbDto({
+      userId: 'host005',
+      streamKey: 'stream005',
+      sessionKey: 'session005',
+      liveId: 'session005',
+      liveTitle: 'Cooking with Pros',
+      category: 'Food',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/test5_thumbnail.png',
+      tags: ['Cooking', 'Food', 'Recipes'],
+      startDate: new Date('2024-11-22T12:00:00'),
+      endDate: new Date('2024-11-22T14:00:00'),
+      state: true,
+      channel: {
+        channelName: 'FoodTV',
+        channelId: '',
+      }
+    }),
+    new MemoryDbDto({
+      userId: 'host006',
+      streamKey: 'stream006',
+      sessionKey: 'session006',
+      liveId: 'session006',
+      liveTitle: 'Tech Conference 2024',
+      category: 'Technology',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/test6_thumbnail.png',
+      tags: ['Tech', 'Conference', 'Innovation'],
+      startDate: new Date('2024-11-22T15:00:00'),
+      endDate: new Date('2024-11-22T18:00:00'),
+      state: true,
+      channel: {
+        channelName: 'TechWorld',
+        channelId: '',
+      }
+    }),
+    new MemoryDbDto({
+      userId: 'host007',
+      streamKey: 'stream007',
+      sessionKey: 'session007',
+      liveId: 'session007',
+      liveTitle: 'Art Masterclass',
+      category: 'Art',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/test7_thumbnail.png',
+      tags: ['Art', 'Painting', 'Creative'],
+      startDate: new Date('2024-11-23T10:00:00'),
+      endDate: new Date('2024-11-23T12:00:00'),
+      state: true,
+      channel: {
+        channelName: 'ArtChannel',
+        channelId: '',
+      }
+    }),
+    new MemoryDbDto({
+      userId: 'host008',
+      streamKey: 'stream008',
+      sessionKey: 'session008',
+      liveId: 'session008',
+      liveTitle: 'Fitness Live Session',
+      category: 'Health',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/test8_thumbnail.png',
+      tags: ['Fitness', 'Health', 'Workout'],
+      startDate: new Date('2024-11-23T16:00:00'),
+      endDate: new Date('2024-11-23T17:00:00'),
+      state: true,
+      channel: {
+        channelName: 'FitTV',
+        channelId: '',
+      }
+    }),
+    new MemoryDbDto({
+      userId: 'host009',
+      streamKey: 'stream009',
+      sessionKey: 'session009',
+      liveId: 'session009',
+      liveTitle: 'Travel Vlog Live',
+      category: 'Travel',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/test9_thumbnail.png',
+      tags: ['Travel', 'Adventure', 'Vlog'],
+      startDate: new Date('2024-11-24T09:00:00'),
+      endDate: new Date('2024-11-24T11:00:00'),
+      state: true,
+      channel: {
+        channelName: 'TravelNow',
+        channelId: '',
+      }
+    }),
+    new MemoryDbDto({
       userId: 'test_replay',
       streamKey: 'replay_stream',
       sessionKey: 'replay_session',
       liveId: 'replay_session',
       liveTitle: 'Replay Title',
       category: 'Replay Category',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/test10_thumbnail.png',
       tags: ['replay', '다시보기'],
       startDate: new Date(Date.now() - 60 * 60 * 1000), // 1 hour ago
       endDate: new Date(Date.now() - 30 * 60 * 1000), // 30 minutes ago
@@ -118,6 +221,90 @@ export class MockDataService implements OnModuleInit {
       liveTitle: 'Replay Music Showcase',
       category: 'Replay Music',
       defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test4_thumbnail.png',
+      tags: ['Replay', 'Music', 'Showcase'],
+      startDate: new Date(Date.now() - 5 * 60 * 60 * 1000), // 5 hours ago
+      endDate: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
+      state: false,
+      replay: true,
+    }),
+    new MemoryDbDto({
+      userId: 'replay_host005',
+      streamKey: 'replay_stream005',
+      sessionKey: 'replay_session005',
+      liveId: 'replay_session005',
+      liveTitle: 'Replay Music Showcase',
+      category: 'Replay Music',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test5_thumbnail.png',
+      tags: ['Replay', 'Music', 'Showcase'],
+      startDate: new Date(Date.now() - 5 * 60 * 60 * 1000), // 5 hours ago
+      endDate: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
+      state: false,
+      replay: true,
+    }),
+    new MemoryDbDto({
+      userId: 'replay_host006',
+      streamKey: 'replay_stream006',
+      sessionKey: 'replay_session006',
+      liveId: 'replay_session006',
+      liveTitle: 'Replay Music Showcase',
+      category: 'Replay Music',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test6_thumbnail.png',
+      tags: ['Replay', 'Music', 'Showcase'],
+      startDate: new Date(Date.now() - 5 * 60 * 60 * 1000), // 5 hours ago
+      endDate: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
+      state: false,
+      replay: true,
+    }),
+    new MemoryDbDto({
+      userId: 'replay_host007',
+      streamKey: 'replay_stream007',
+      sessionKey: 'replay_session007',
+      liveId: 'replay_session007',
+      liveTitle: 'Replay Music Showcase',
+      category: 'Replay Music',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test7_thumbnail.png',
+      tags: ['Replay', 'Music', 'Showcase'],
+      startDate: new Date(Date.now() - 5 * 60 * 60 * 1000), // 5 hours ago
+      endDate: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
+      state: false,
+      replay: true,
+    }),
+    new MemoryDbDto({
+      userId: 'replay_host008',
+      streamKey: 'replay_stream008',
+      sessionKey: 'replay_session008',
+      liveId: 'replay_session008',
+      liveTitle: 'Replay Music Showcase',
+      category: 'Replay Music',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test8_thumbnail.png',
+      tags: ['Replay', 'Music', 'Showcase'],
+      startDate: new Date(Date.now() - 5 * 60 * 60 * 1000), // 5 hours ago
+      endDate: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
+      state: false,
+      replay: true,
+    }),
+    new MemoryDbDto({
+      userId: 'replay_host009',
+      streamKey: 'replay_stream009',
+      sessionKey: 'replay_session009',
+      liveId: 'replay_session009',
+      liveTitle: 'Replay Music Showcase',
+      category: 'Replay Music',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test9_thumbnail.png',
+      tags: ['Replay', 'Music', 'Showcase'],
+      startDate: new Date(Date.now() - 5 * 60 * 60 * 1000), // 5 hours ago
+      endDate: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
+      state: false,
+      replay: true,
+    }),
+    new MemoryDbDto({
+      userId: 'replay_host010',
+      streamKey: 'replay_stream010',
+      sessionKey: 'replay_session010',
+      liveId: 'replay_session010',
+      liveTitle: 'Replay Music Showcase',
+      category: 'Replay Music',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test10_thumbnail.png',
       tags: ['Replay', 'Music', 'Showcase'],
       startDate: new Date(Date.now() - 5 * 60 * 60 * 1000), // 5 hours ago
       endDate: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago

--- a/backend/mainServer/src/mock-data/mock-data.service.ts
+++ b/backend/mainServer/src/mock-data/mock-data.service.ts
@@ -68,6 +68,62 @@ export class MockDataService implements OnModuleInit {
       endDate: new Date(Date.now() - 30 * 60 * 1000), // 30 minutes ago
       state: true,
     }),
+    new MemoryDbDto({
+      userId: 'replay_host001',
+      streamKey: 'replay_stream001',
+      sessionKey: 'replay_session001',
+      liveId: 'replay_session001',
+      liveTitle: 'Replay Tech Conference 2024',
+      category: 'Replay Technology',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test1_thumbnail.png',
+      tags: ['Replay', 'Conference', 'Tech'],
+      startDate: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2 hours ago
+      endDate: new Date(Date.now() - 90 * 60 * 1000), // 90 minutes ago
+      state: false,
+      replay: true,
+    }),
+    new MemoryDbDto({
+      userId: 'replay_host002',
+      streamKey: 'replay_stream002',
+      sessionKey: 'replay_session002',
+      liveId: 'replay_session002',
+      liveTitle: 'Replay DAN24',
+      category: 'Replay Art',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test2_thumbnail.png',
+      tags: ['Replay', 'Dan', 'Art'],
+      startDate: new Date(Date.now() - 3 * 60 * 60 * 1000), // 3 hours ago
+      endDate: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2 hours ago
+      state: false,
+      replay: true,
+    }),
+    new MemoryDbDto({
+      userId: 'replay_host003',
+      streamKey: 'replay_stream003',
+      sessionKey: 'replay_session003',
+      liveId: 'replay_session003',
+      liveTitle: 'Replay Gaming Tournament Finals',
+      category: 'Replay Gaming',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test3_thumbnail.png',
+      tags: ['Replay', 'Gaming', 'Esports'],
+      startDate: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
+      endDate: new Date(Date.now() - 3 * 60 * 60 * 1000), // 3 hours ago
+      state: false,
+      replay: true,
+    }),
+    new MemoryDbDto({
+      userId: 'replay_host004',
+      streamKey: 'replay_stream004',
+      sessionKey: 'replay_session004',
+      liveId: 'replay_session004',
+      liveTitle: 'Replay Music Showcase',
+      category: 'Replay Music',
+      defaultThumbnailImageUrl: 'https://kr.object.ncloudstorage.com/web22/static/replay_test4_thumbnail.png',
+      tags: ['Replay', 'Music', 'Showcase'],
+      startDate: new Date(Date.now() - 5 * 60 * 60 * 1000), // 5 hours ago
+      endDate: new Date(Date.now() - 4 * 60 * 60 * 1000), // 4 hours ago
+      state: false,
+      replay: true,
+    }),
   ];
 
   constructor(private readonly memoryDbService: MemoryDBService) {}

--- a/backend/mainServer/src/replay/replay.controller.spec.ts
+++ b/backend/mainServer/src/replay/replay.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReplayController } from './replay.controller';
+import { ReplayService } from './replay.service';
+
+describe('ReplayController', () => {
+  let controller: ReplayController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReplayController],
+      providers: [ReplayService],
+    }).compile();
+
+    controller = module.get<ReplayController>(ReplayController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/mainServer/src/replay/replay.controller.ts
+++ b/backend/mainServer/src/replay/replay.controller.ts
@@ -4,17 +4,21 @@ import { ReplayService } from './replay.service.js';
 import { MemoryDBService } from '../memory-db/memory-db.service.js';
 import { memoryDbDtoToReplayVideoDto } from '../common/transformers.js';
 import { MemoryDbDto } from '../dto/memoryDbDto.js';
+import { ReplayVideoDto } from 'src/dto/replayVideoDto.js';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
 @Controller('replay')
 export class ReplayController {
   constructor(private readonly replayService: ReplayService, private readonly memoryDBService: MemoryDBService) {}
 
   @Get('/latest')
+  @ApiOperation({summary: 'Get 8ea Replay And 8ea Append Replay Info', description: '가장 최근에 등록된 다시보기 8개와 추가 8개의 다시보기를 불러옵니다. (다시보기가 없을 경우 빈 배열 반환)'})
+  @ApiOkResponse({description: '정상적으로 데이터를 불러왔습니다.'})
   async getLatestReplay(@Res() res: Response) {
     try {
       const replayChecker = (item: MemoryDbDto) => { return item.replay && !item.state; };
-      const serchedData = this.memoryDBService.getBroadcastInfo(8, memoryDbDtoToReplayVideoDto, replayChecker);
-      res.status(HttpStatus.OK).json({info: serchedData});
+      const [serchedData, appendData] = this.memoryDBService.getBroadcastInfo<ReplayVideoDto>(8, memoryDbDtoToReplayVideoDto, replayChecker, 8);
+      res.status(HttpStatus.OK).json({info: serchedData, appendInfo: appendData});
     } catch (error) {
       if ((error as { status: number }).status === 400) {
         res.status(HttpStatus.BAD_REQUEST).json({
@@ -30,6 +34,7 @@ export class ReplayController {
   }
 
   @Get('/video')
+  @ApiOperation({summary : 'Get Replay Info', description:'videoId에 대해 다시보기 정보를 불러옵니다.'})
   async getReplayInfo(@Query('videoId') sessionKey: string, @Res() res: Response) {
     try {
       const sessionInfo = this.memoryDBService.findBySessionKey(sessionKey);

--- a/backend/mainServer/src/replay/replay.controller.ts
+++ b/backend/mainServer/src/replay/replay.controller.ts
@@ -4,7 +4,7 @@ import { ReplayService } from './replay.service.js';
 import { MemoryDBService } from '../memory-db/memory-db.service.js';
 import { memoryDbDtoToReplayVideoDto } from '../common/transformers.js';
 import { MemoryDbDto } from '../dto/memoryDbDto.js';
-import { ReplayVideoDto } from 'src/dto/replayVideoDto.js';
+import { ReplayVideoDto } from '../dto/replayVideoDto.js';
 import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
 @Controller('replay')

--- a/backend/mainServer/src/replay/replay.controller.ts
+++ b/backend/mainServer/src/replay/replay.controller.ts
@@ -12,7 +12,7 @@ export class ReplayController {
   @Get('/latest')
   async getLatestReplay(@Res() res: Response) {
     try {
-      const replayChecker = (item: MemoryDbDto) => item.replay;
+      const replayChecker = (item: MemoryDbDto) => { return item.replay && !item.state; };
       const serchedData = this.memoryDBService.getBroadcastInfo(8, memoryDbDtoToReplayVideoDto, replayChecker);
       res.status(HttpStatus.OK).json({info: serchedData});
     } catch (error) {

--- a/backend/mainServer/src/replay/replay.controller.ts
+++ b/backend/mainServer/src/replay/replay.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Res, HttpStatus } from '@nestjs/common';
+import { Response } from 'express';
+import { ReplayService } from './replay.service.js';
+import { MemoryDBService } from '../memory-db/memory-db.service.js';
+import { memoryDbDtoToReplayVideoDto } from '../common/transformers.js';
+import { MemoryDbDto } from '../dto/memoryDbDto.js';
+
+@Controller('replay')
+export class ReplayController {
+  constructor(private readonly replayService: ReplayService, private readonly memoryDBService: MemoryDBService) {}
+
+  @Get('/latest')
+  async getLatestSession(@Res() res: Response) {
+    try {
+      const replayChecker = (item: MemoryDbDto) => item.replay;
+      const serchedData = this.memoryDBService.getBroadcastInfo(8, memoryDbDtoToReplayVideoDto, replayChecker);
+      res.status(HttpStatus.OK).json({info: serchedData});
+    } catch (error) {
+      if ((error as { status: number }).status === 400) {
+        res.status(HttpStatus.BAD_REQUEST).json({
+          error: (error as { response: Response }).response
+        });
+      }
+      else {
+        res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+          error: 'Server logic error',
+        });
+      }
+    }
+  }
+}

--- a/backend/mainServer/src/replay/replay.controller.ts
+++ b/backend/mainServer/src/replay/replay.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Res, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Res, HttpStatus, Query, HttpException } from '@nestjs/common';
 import { Response } from 'express';
 import { ReplayService } from './replay.service.js';
 import { MemoryDBService } from '../memory-db/memory-db.service.js';
@@ -10,7 +10,7 @@ export class ReplayController {
   constructor(private readonly replayService: ReplayService, private readonly memoryDBService: MemoryDBService) {}
 
   @Get('/latest')
-  async getLatestSession(@Res() res: Response) {
+  async getLatestReplay(@Res() res: Response) {
     try {
       const replayChecker = (item: MemoryDbDto) => item.replay;
       const serchedData = this.memoryDBService.getBroadcastInfo(8, memoryDbDtoToReplayVideoDto, replayChecker);
@@ -28,4 +28,27 @@ export class ReplayController {
       }
     }
   }
+
+  @Get('/video')
+  async getReplayInfo(@Query('videoId') sessionKey: string, @Res() res: Response) {
+    try {
+      const sessionInfo = this.memoryDBService.findBySessionKey(sessionKey);
+      if (!sessionInfo && !sessionInfo.replay) {
+        throw new HttpException('No Available Session', HttpStatus.BAD_REQUEST);
+      }
+      res.status(HttpStatus.OK).json({info : memoryDbDtoToReplayVideoDto(sessionInfo)});
+    } catch (error) {
+      if ((error as { status: number }).status === 400) {
+        res.status(HttpStatus.BAD_REQUEST).json({
+          error: (error as { response: Response }).response
+        });
+      }
+      else {
+        res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+          error: 'Server logic error',
+        });
+      }
+    }
+  }
+
 }

--- a/backend/mainServer/src/replay/replay.controller.ts
+++ b/backend/mainServer/src/replay/replay.controller.ts
@@ -33,7 +33,7 @@ export class ReplayController {
   async getReplayInfo(@Query('videoId') sessionKey: string, @Res() res: Response) {
     try {
       const sessionInfo = this.memoryDBService.findBySessionKey(sessionKey);
-      if (!sessionInfo && !sessionInfo.replay) {
+      if (!sessionInfo || !sessionInfo.replay) {
         throw new HttpException('No Available Session', HttpStatus.BAD_REQUEST);
       }
       res.status(HttpStatus.OK).json({info : memoryDbDtoToReplayVideoDto(sessionInfo)});

--- a/backend/mainServer/src/replay/replay.module.ts
+++ b/backend/mainServer/src/replay/replay.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ReplayService } from './replay.service.js';
+import { ReplayController } from './replay.controller.js';
+import { MemoryDBModule } from '../memory-db/memory-db.module.js';
+
+@Module({
+  imports: [MemoryDBModule],
+  controllers: [ReplayController],
+  providers: [ReplayService],
+})
+export class ReplayModule {}

--- a/backend/mainServer/src/replay/replay.service.spec.ts
+++ b/backend/mainServer/src/replay/replay.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReplayService } from './replay.service';
+
+describe('ReplayService', () => {
+  let service: ReplayService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ReplayService],
+    }).compile();
+
+    service = module.get<ReplayService>(ReplayService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/mainServer/src/replay/replay.service.ts
+++ b/backend/mainServer/src/replay/replay.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ReplayService {
+
+}

--- a/backend/mainServer/src/streams/streams.controller.ts
+++ b/backend/mainServer/src/streams/streams.controller.ts
@@ -4,6 +4,7 @@ import { Response } from 'express';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MemoryDBService } from '../memory-db/memory-db.service.js';
 import { fromLiveSessionDto } from '../dto/liveSessionDto.js';
+import { MemoryDbDto } from '../dto/memoryDbDto.js';
 
 @ApiTags('Stream Information API')
 @Controller('streams')
@@ -35,7 +36,8 @@ export class StreamsController {
   @ApiOperation({summary : 'Get Live Session Notice', description:'현재 진행 중인 라이브 정보를 최신부터 8개씩 불러옵니다.'})
   async getLatestSession(@Res() res: Response) {
     try {
-      const serchedData = this.memoryDBService.getBroadcastInfo(8);
+      const streamChecker = (item: MemoryDbDto) => item.state;
+      const serchedData = this.memoryDBService.getBroadcastInfo(8, fromLiveSessionDto, streamChecker);
       res.status(HttpStatus.OK).json({info: serchedData});
     } catch (error) {
       if ((error as { status: number }).status === 400) {

--- a/backend/mainServer/src/streams/streams.controller.ts
+++ b/backend/mainServer/src/streams/streams.controller.ts
@@ -3,7 +3,7 @@ import { StreamsService } from './streams.service.js';
 import { Response } from 'express';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { MemoryDBService } from '../memory-db/memory-db.service.js';
-import { fromLiveSessionDto } from '../dto/liveSessionDto.js';
+import { fromLiveSessionDto, LiveSessionResponseDto } from '../dto/liveSessionDto.js';
 import { MemoryDbDto } from '../dto/memoryDbDto.js';
 
 @ApiTags('Stream Information API')
@@ -12,7 +12,7 @@ export class StreamsController {
   constructor( private readonly memoryDBService: MemoryDBService,  private readonly streamsService: StreamsService) { }
 
   @Get('/random')
-  @ApiOperation({ summary: 'Get 4ea Broadcas Info API', description: '랜덤하게 4개의 방송 정보를 받아온다.' })
+  @ApiOperation({ summary: 'Get 4ea Broadcas Info API', description: '랜덤하게 4개의 방송 정보를 받아온다. (방송이 없을 경우 빈 배열 반환)' })
   @ApiResponse({ status: 200, description: '랜덤한 4개의 방송 정보를 받았습니다.' })
   async findSession(@Res() res: Response) {
     try {
@@ -33,12 +33,12 @@ export class StreamsController {
   }
 
   @Get('/latest')
-  @ApiOperation({summary : 'Get Live Session Notice', description:'현재 진행 중인 라이브 정보를 최신부터 8개씩 불러옵니다.'})
+  @ApiOperation({summary : 'Get 8ea Live Session And 8ea Append Session Info', description:'현재 진행 중인 라이브 정보를 최신부터 8개, 추가 정보 8개씩 불러옵니다. (방송이 없을 경우 빈 배열 반환)'})
   async getLatestSession(@Res() res: Response) {
     try {
       const streamChecker = (item: MemoryDbDto) => item.state;
-      const serchedData = this.memoryDBService.getBroadcastInfo(8, fromLiveSessionDto, streamChecker);
-      res.status(HttpStatus.OK).json({info: serchedData});
+      const [serchedData, appendData] = this.memoryDBService.getBroadcastInfo<LiveSessionResponseDto>(8, fromLiveSessionDto, streamChecker, 8);
+      res.status(HttpStatus.OK).json({info: serchedData, appendInfo: appendData});
     } catch (error) {
       if ((error as { status: number }).status === 400) {
         res.status(HttpStatus.BAD_REQUEST).json({
@@ -54,7 +54,7 @@ export class StreamsController {
   }
 
   @Get('/live')
-  @ApiOperation({summary : 'Get Live Session Notice', description:'현재 진행 중인 방송 정보를 불러옵니다.'})
+  @ApiOperation({summary : 'Get Live Session Info', description:'liveId에 대해 현재 진행 중인 방송 정보를 불러옵니다.'})
   async getSessionInfo(@Query('liveId') sessionKey: string, @Res() res: Response) {
     try {
       const sessionInfo = this.memoryDBService.findBySessionKey(sessionKey);
@@ -78,7 +78,7 @@ export class StreamsController {
 
 
   @Get('/notice')
-  @ApiOperation({summary : 'Get 8ea Live Session Info', description:'현재 진행 중인 방송 공지를 받아옵니다.'})
+  @ApiOperation({summary : 'Get Live Session Notice', description:'현재 진행 중인 방송 공지를 받아옵니다.'})
   async getNotice(@Query('sessionKey') sessionKey : string, @Res() res: Response) {
     try {
       const sessionInfo = this.memoryDBService.findBySessionKey(sessionKey);

--- a/backend/rtmpServer/package.json
+++ b/backend/rtmpServer/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "packageManager": "yarn@4.5.1",
   "dependencies": {
+    "@hoeeeeeh/node-media-server": "2.8.5",
     "@hoeeeeeh/test-node-media-server": "0.0.1",
     "@types/node": "^22.9.0",
     "dotenv": "^16.4.5",

--- a/backend/rtmpServer/package.json
+++ b/backend/rtmpServer/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "yarn@4.5.1",
   "dependencies": {
-    "@hoeeeeeh/node-media-server": "2.8.5",
+    "@hoeeeeeh/test-node-media-server": "0.0.1",
     "@types/node": "^22.9.0",
     "dotenv": "^16.4.5",
     "path": "0.12.7"

--- a/backend/rtmpServer/src/index.ts
+++ b/backend/rtmpServer/src/index.ts
@@ -1,4 +1,4 @@
-import NodeMediaServer from '@hoeeeeeh/node-media-server';
+import NodeMediaServer from '@hoeeeeeh/test-node-media-server';
 
 import dotenv from 'dotenv';
 import path from 'path';

--- a/backend/rtmpServer/src/index.ts
+++ b/backend/rtmpServer/src/index.ts
@@ -1,4 +1,4 @@
-import NodeMediaServer from '@hoeeeeeh/test-node-media-server';
+import NodeMediaServer from '@hoeeeeeh/node-media-server';
 
 import dotenv from 'dotenv';
 import path from 'path';

--- a/backend/rtmpServer/src/index.ts
+++ b/backend/rtmpServer/src/index.ts
@@ -36,7 +36,10 @@ const transformationConfig = {
       app: 'live',
       hls: true,
       hlsFlags: '[hls_time=2:hls_list_size=3:hls_flags=delete_segments]',
-      hlsKeep: false
+      vc: 'libx264',
+      vcParam: ['-g', '60', '-keyint_min', '60', '-sc_threshold', '0'],
+      ac: 'copy',
+      ffmpegLogLevel: 'verbose'
     }
   ],
   //package.json 기준

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,6 +2689,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hoeeeeeh/node-media-server@npm:2.8.5":
+  version: 2.8.5
+  resolution: "@hoeeeeeh/node-media-server@npm:2.8.5"
+  dependencies:
+    "@aws-sdk/client-s3": "npm:^3.688.0"
+    "@types/node": "npm:^22.9.0"
+    basic-auth-connect: "npm:^1.0.0"
+    body-parser: "npm:1.20.3"
+    chalk: "npm:^4.1.0"
+    dateformat: "npm:^4.6.3"
+    express: "npm:^4.19.2"
+    http2-express-bridge: "npm:^1.0.7"
+    lodash: "npm:^4.17.21"
+    minimist: "npm:^1.2.8"
+    mkdirp: "npm:^2.1.5"
+    ws: "npm:^8.13.0"
+  bin:
+    node-media-server: bin/app.js
+  checksum: 10c0/a2ee39f41182b49c5cabcbf1f87ea16e97f5842bfb02c5ee10e11cbb921bbccfcc7dee0ec7ffbfe8b4e35e97bf3acdca42d5e1383f0836bdc78f4af198de585b
+  languageName: node
+  linkType: hard
+
 "@hoeeeeeh/test-node-media-server@npm:0.0.1":
   version: 0.0.1
   resolution: "@hoeeeeeh/test-node-media-server@npm:0.0.1"
@@ -11470,6 +11492,7 @@ __metadata:
   resolution: "rtmpServer@workspace:backend/rtmpServer"
   dependencies:
     "@eslint/js": "npm:^9.13.0"
+    "@hoeeeeeh/node-media-server": "npm:2.8.5"
     "@hoeeeeeh/test-node-media-server": "npm:0.0.1"
     "@types/node": "npm:^22.9.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,9 +2689,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hoeeeeeh/node-media-server@npm:2.8.5":
-  version: 2.8.5
-  resolution: "@hoeeeeeh/node-media-server@npm:2.8.5"
+"@hoeeeeeh/test-node-media-server@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@hoeeeeeh/test-node-media-server@npm:0.0.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.688.0"
     "@types/node": "npm:^22.9.0"
@@ -2706,8 +2706,8 @@ __metadata:
     mkdirp: "npm:^2.1.5"
     ws: "npm:^8.13.0"
   bin:
-    node-media-server: bin/app.js
-  checksum: 10c0/a2ee39f41182b49c5cabcbf1f87ea16e97f5842bfb02c5ee10e11cbb921bbccfcc7dee0ec7ffbfe8b4e35e97bf3acdca42d5e1383f0836bdc78f4af198de585b
+    test-node-media-server: bin/app.js
+  checksum: 10c0/2fb08d22ab0f14061132eec86bb62d1e2c44d72067b70f5dcbafe48a123765de9c7c023ca2e3d44c93e17012c68a3d33ee6ae3ca3d8d41cd0a8eea355484d964
   languageName: node
   linkType: hard
 
@@ -11470,7 +11470,7 @@ __metadata:
   resolution: "rtmpServer@workspace:backend/rtmpServer"
   dependencies:
     "@eslint/js": "npm:^9.13.0"
-    "@hoeeeeeh/node-media-server": "npm:2.8.5"
+    "@hoeeeeeh/test-node-media-server": "npm:0.0.1"
     "@types/node": "npm:^22.9.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.14.0"
     "@typescript-eslint/parser": "npm:^8.14.0"


### PR DESCRIPTION
## 🚀 Issue Number
<!-- - resolve: #{Number} -->
- resolve: #190 
- resolve: #32 
- resolve: #47 

## 주요 작업
- 기존에 유동적으로 키 프레임이 잘리던 rtmp 서버를 고정적인 값으로 자르도록 코드 수정
- 다시보기 영상 최신 8개, 단일 1개에 대한 Get API 작성

## 고민과 해결 과정
- 현재 다시보기 m3u8의 생성을 obs가 전달하는 방송 시작/종료 시간에 의존하고 있는데, 이 때문에 약간의 오차가 발생
  - 이를 해결하기 위해 임의로 방송 시간을 줄이는 방식으로 0 ~ (방송 시작 진행 시간) / 2 - 5 개 만큼의 ts 데이터를 작성해서 m3u8로 업로드
  - 보통은 마무리에는 큰 상관이 없다고 판단해서 일단 데이터가 많으면 10초에서 적으면 2~4초 유실되는 문제점이 있다.
  - 나중에 어떻게 잘 하면 고칠 수 있지 않을까 생각중입니다.

## 📸 Screenshots


## 🔜 추가 내용 (선택)
