### PR TITLE
[CHORE] node-media-server version 변경

### DIFF
--- a/backend/rtmpServer/package.json
+++ b/backend/rtmpServer/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "yarn@4.5.1",
   "dependencies": {
-    "@hoeeeeeh/node-media-server": "2.8.5",
+    "@hoeeeeeh/node-media-server": "3.0.0",
     "@types/node": "^22.9.0",
     "dotenv": "^16.4.5",
     "path": "0.12.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,9 +2689,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hoeeeeeh/node-media-server@npm:2.8.5":
-  version: 2.8.5
-  resolution: "@hoeeeeeh/node-media-server@npm:2.8.5"
+"@hoeeeeeh/node-media-server@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@hoeeeeeh/node-media-server@npm:3.0.0"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.688.0"
     "@types/node": "npm:^22.9.0"
@@ -11625,7 +11625,7 @@ __metadata:
   resolution: "rtmpServer@workspace:backend/rtmpServer"
   dependencies:
     "@eslint/js": "npm:^9.13.0"
-    "@hoeeeeeh/node-media-server": "npm:2.8.5"
+    "@hoeeeeeh/node-media-server": "npm:3.0.0"
     "@types/node": "npm:^22.9.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.14.0"
     "@typescript-eslint/parser": "npm:^8.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2707,7 +2707,7 @@ __metadata:
     ws: "npm:^8.13.0"
   bin:
     node-media-server: bin/app.js
-  checksum: 10c0/a2ee39f41182b49c5cabcbf1f87ea16e97f5842bfb02c5ee10e11cbb921bbccfcc7dee0ec7ffbfe8b4e35e97bf3acdca42d5e1383f0836bdc78f4af198de585b
+  checksum: 10c0/8fe309734ff534525bdc0a3e9cac9f6829085a71fce6286f2980e599c70bef4bb74ade7bfe4e8a7aea7b1b8924527b472c9e48ef9029bd6df157e80e6eed84a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🚀 Issue Number
<!-- - resolve: #{Number} -->

## 주요 작업
<!-- 문제 상황 정의 -->
node media server 의 기본 셋팅은 cpu 를 최대한 많이 사용하도록 되어 있습니다.
서버의 cpu 사용률이 너무 과다해질 수 있습니다.
## 고민과 해결 과정
<!-- 변경 사항 -->
ffmpeg 이 thread 2개로 고정 사용하도록 옵션을 걸어주었습니다.

## 📸 Screenshots


## 🔜 추가 내용 (선택)
