### PR TITLE
[REFACTOR] 채팅창 컴포넌트 렌더링 최적화 및 비제어 컴포넌트로 개선

### DIFF
--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -6,16 +6,24 @@ import LayerPopup from './LayerPopup';
 import { ChatContext } from 'src/contexts/chatContext';
 
 interface ChatHeaderProps {
-  outBtnHandler?: () => void;
+  outBtnHandler: () => void;
 }
+
+const MemoizedHeaderBtn = memo(({ onClick, icon }: { onClick: () => void; icon: string }) => (
+  <HeaderBtn onClick={onClick}>
+    <StyledIcon as={icon} />
+  </HeaderBtn>
+));
+
+MemoizedHeaderBtn.displayName = 'MemoizedHeaderBtn';
 
 export const ChatHeader = ({ outBtnHandler }: ChatHeaderProps) => {
   const { state, dispatch } = useContext(ChatContext);
   const headerRef = useRef<HTMLDivElement>(null);
 
-  const toggleSettings = () => {
+  const toggleSettings = useCallback(() => {
     dispatch({ type: 'TOGGLE_SETTINGS' });
-  };
+  }, [dispatch]);
 
   const handleClickOutside = useCallback(
     (event: MouseEvent) => {
@@ -35,19 +43,16 @@ export const ChatHeader = ({ outBtnHandler }: ChatHeaderProps) => {
 
   return (
     <ChatHeaderContainer ref={headerRef}>
-      <HeaderBtn onClick={outBtnHandler}>
-        <StyledIcon as={OutIcon} />
-      </HeaderBtn>
+      <MemoizedHeaderBtn onClick={outBtnHandler} icon={OutIcon} />
       <h2>채팅</h2>
-      <HeaderBtn onClick={toggleSettings}>
-        <StyledIcon as={ThreePointIcon} />
-      </HeaderBtn>
+      <MemoizedHeaderBtn onClick={toggleSettings} icon={ThreePointIcon} />
+
       <PopupWrapper>{state.isSettingsOpen && <LayerPopup />}</PopupWrapper>
     </ChatHeaderContainer>
   );
 };
 
-export default memo(ChatHeader);
+export default ChatHeader;
 
 const ChatHeaderContainer = styled.div`
   position: relative;

--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -54,10 +54,10 @@ const ChatHeaderContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 15px 15px;
+  padding: 10px 10px;
   border-top: 1px solid ${({ theme }) => theme.tokenColors['surface-alt']};
   color: ${({ theme }) => theme.tokenColors['color-white']};
-  ${({ theme }) => theme.tokenTypographys['display-bold20']};
+  ${({ theme }) => theme.tokenTypographys['display-bold16']};
 `;
 
 const HeaderBtn = styled.button`
@@ -67,8 +67,8 @@ const HeaderBtn = styled.button`
 `;
 
 const StyledIcon = styled.svg`
-  width: 25px;
-  height: 25px;
+  width: 22px;
+  height: 22px;
   cursor: pointer;
 `;
 

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -15,7 +15,7 @@ interface ChatInputProps {
   roomId: string;
 }
 
-const INITIAL_TEXTAREA_HEIGHT = 15;
+const INITIAL_TEXTAREA_HEIGHT = 20;
 
 export const ChatInput = ({ worker, userType, roomId }: ChatInputProps) => {
   const [hasInput, setHasInput] = useState(false);
@@ -101,7 +101,7 @@ export const ChatInput = ({ worker, userType, roomId }: ChatInputProps) => {
         textarea.removeEventListener('input', handleResize);
       }
     };
-  }, [textareaRef.current]);
+  }, []);
 
   const handleBlur = () => {
     if (textareaRef.current) {
@@ -184,7 +184,7 @@ const ChatInputWrapper = styled.div<{ $hasInput: boolean; $isFocused: boolean }>
 
 const ChatInputArea = styled.textarea`
   width: 100%;
-  max-height: 65px;
+  min-height: 20px;
   scrollbar-width: none;
   resize: none;
   border: none;

--- a/frontend/src/components/chat/ChatList.tsx
+++ b/frontend/src/components/chat/ChatList.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import QuestionCard from './QuestionCard';
-import { useContext, useEffect, useRef, useState } from 'react';
+import { memo, useContext, useEffect, useRef, useState } from 'react';
 import { MessageReceiveData } from '@type/chat';
 import { CHATTING_TYPES } from '@constants/chat';
 import { ChatContext } from 'src/contexts/chatContext';
@@ -11,6 +11,41 @@ import HostIconGreen from '@assets/icons/host_icon_green.svg';
 export interface ChatListProps {
   messages: MessageReceiveData[];
 }
+
+const ChatItemWrapper = memo(({ chat }: { chat: MessageReceiveData }) => {
+  if (chat.msgType === CHATTING_TYPES.QUESTION) {
+    return (
+      <ChatItem>
+        <QuestionCard type="client" question={chat} />
+      </ChatItem>
+    );
+  } else if (chat.msgType === CHATTING_TYPES.NOTICE) {
+    return (
+      <ChatItem>
+        <NoticeChat>
+          <span>📢</span>
+          <span>{chat.msg}</span>
+        </NoticeChat>
+      </ChatItem>
+    );
+  } else {
+    return (
+      <ChatItem>
+        <NormalChat $isHost={chat.owner === 'host'} $pointColor={chat.owner === 'host' ? '#0ADD91' : chat.color}>
+          {chat.owner === 'me' ? (
+            <span className="text_point">🧀</span>
+          ) : chat.owner === 'host' ? (
+            <StyledIcon as={HostIconGreen} />
+          ) : null}
+          <span className="text_point">{chat.nickname}</span>
+          <span className="chat_message">{chat.msg}</span>
+        </NormalChat>
+      </ChatItem>
+    );
+  }
+});
+
+ChatItemWrapper.displayName = 'ChatItemWrapper';
 
 const ChatList = ({ messages }: ChatListProps) => {
   const { state } = useContext(ChatContext);
@@ -48,26 +83,7 @@ const ChatList = ({ messages }: ChatListProps) => {
     <ChatListSection>
       <ChatListWrapper ref={chatListRef} onScroll={checkIfAtBottom}>
         {messages.map((chat, index) => (
-          <ChatItemWrapper key={index}>
-            {chat.msgType === CHATTING_TYPES.QUESTION ? (
-              <QuestionCard type="client" question={chat} />
-            ) : chat.msgType === CHATTING_TYPES.NOTICE ? (
-              <NoticeChat>
-                <span>📢</span>
-                <span>{chat.msg}</span>
-              </NoticeChat>
-            ) : (
-              <NormalChat $isHost={chat.owner === 'host'} $pointColor={chat.owner === 'host' ? '#0ADD91' : chat.color}>
-                {chat.owner === 'me' ? (
-                  <span className="text_point">🧀</span>
-                ) : chat.owner === 'host' ? (
-                  <StyledIcon as={HostIconGreen} />
-                ) : null}
-                <span className="text_point">{chat.nickname}</span>
-                <span className="chat_message">{chat.msg}</span>
-              </NormalChat>
-            )}
-          </ChatItemWrapper>
+          <ChatItemWrapper chat={chat} key={index} />
         ))}
       </ChatListWrapper>
       <ChatAutoScroll currentChat={currentChat} isAtBottom={isAtBottom} scrollToBottom={scrollToBottom} />
@@ -103,7 +119,7 @@ const ChatListWrapper = styled.div`
   z-index: 100;
 `;
 
-const ChatItemWrapper = styled.div`
+const ChatItem = styled.div`
   margin-top: auto;
   padding: 6px 0;
 `;
@@ -151,5 +167,5 @@ const StyledIcon = styled.svg`
   width: 18px;
   height: 18px;
   cursor: pointer;
-  margin: 0 5px -4px 0;
+  margin: 0 5px -4.5px 0;
 `;

--- a/frontend/src/components/chat/ChatQuestionSection.tsx
+++ b/frontend/src/components/chat/ChatQuestionSection.tsx
@@ -100,12 +100,12 @@ const SwipeBtn = styled.button`
   &::before {
     content: '';
     position: absolute;
-    top: 45%;
+    top: 40%;
     left: 50%;
     background-color: ${({ theme }) => theme.tokenColors['text-weak']};
     border-radius: 2px;
-    height: 5px;
-    width: 50px;
+    height: 4px;
+    width: 60px;
     transform: translate(-50%, -50%);
   }
 `;

--- a/frontend/src/components/chat/ChatQuestionSection.tsx
+++ b/frontend/src/components/chat/ChatQuestionSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState, useCallback } from 'react';
 import styled from 'styled-components';
 import QuestionCard from './QuestionCard';
 import { MessageReceiveData, MessageSendData } from '@type/chat';
@@ -13,27 +13,30 @@ export interface ChatQuestionSectionProps {
   roomId: string;
 }
 
-export const ChatQuestionSection = ({ questions, worker, userType, roomId }: ChatQuestionSectionProps) => {
+const ChatQuestionSection = ({ questions, worker, userType, roomId }: ChatQuestionSectionProps) => {
   const [expanded, setExpanded] = useState(false);
 
   const userId = getStoredId();
 
-  const toggleSection = () => {
+  const toggleSection = useCallback(() => {
     setExpanded((prev) => !prev);
-  };
+  }, []);
 
-  const handleQuestionDone = (questionId: number) => {
-    if (!worker) return;
+  const handleQuestionDone = useCallback(
+    (questionId: number) => {
+      if (!worker) return;
 
-    worker.postMessage({
-      type: CHATTING_SOCKET_SEND_EVENT.QUESTION_DONE,
-      payload: {
-        roomId,
-        userId,
-        questionId
-      } as MessageSendData
-    });
-  };
+      worker.postMessage({
+        type: CHATTING_SOCKET_SEND_EVENT.QUESTION_DONE,
+        payload: {
+          roomId,
+          userId,
+          questionId
+        } as MessageSendData
+      });
+    },
+    [worker, roomId, userId]
+  );
 
   return (
     <SectionWrapper>
@@ -67,7 +70,8 @@ export const ChatQuestionSection = ({ questions, worker, userType, roomId }: Cha
     </SectionWrapper>
   );
 };
-export default ChatQuestionSection;
+
+export default memo(ChatQuestionSection);
 
 const SectionWrapper = styled.div`
   position: relative;
@@ -89,7 +93,7 @@ const SectionContainer = styled.div`
   gap: 10px;
 `;
 
-const SwipeBtn = styled.button`
+const SwipeBtn = memo(styled.button`
   position: absolute;
   bottom: 0;
   left: 0;
@@ -108,7 +112,7 @@ const SwipeBtn = styled.button`
     width: 60px;
     transform: translate(-50%, -50%);
   }
-`;
+`);
 
 const NoQuestionMessage = styled.div`
   text-align: center;

--- a/frontend/src/components/chat/ChatRoomLayout.tsx
+++ b/frontend/src/components/chat/ChatRoomLayout.tsx
@@ -5,7 +5,7 @@ import ChatList from './ChatList';
 import ChatQuestionSection from './ChatQuestionSection';
 
 import { UserType } from '@type/user';
-import { useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useChatRoom } from '@hooks/useChatRoom';
 import { getStoredId } from '@utils/id';
 
@@ -14,26 +14,32 @@ interface ChatRoomLayoutProps {
   roomId: string;
 }
 
-export const ChatRoomLayout = ({ userType, roomId }: ChatRoomLayoutProps) => {
+const ChatRoomLayout = ({ userType, roomId }: ChatRoomLayoutProps) => {
   const [isChatRoomVisible, setIsChatRoomVisible] = useState(true);
 
   const userId = getStoredId();
   const { worker, messages, questions } = useChatRoom(roomId as string, userId);
 
+  const handleCloseChatRoom = useCallback(() => {
+    setIsChatRoomVisible(false);
+  }, []);
+
+  const handleOpenChatRoom = useCallback(() => {
+    setIsChatRoomVisible(true);
+  }, []);
+
   return (
     <>
-      <ChatOpenBtn $isVisible={!isChatRoomVisible} onClick={() => setIsChatRoomVisible(true)}>
+      <ChatOpenBtn $isVisible={!isChatRoomVisible} onClick={handleOpenChatRoom}>
         채팅 보기
       </ChatOpenBtn>
 
       <ChatRoomContainer $isVisible={isChatRoomVisible}>
-        <ChatHeader outBtnHandler={() => setIsChatRoomVisible(false)} />
+        <ChatHeader outBtnHandler={handleCloseChatRoom} />
 
         <ChatQuestionSection questions={questions} worker={worker} userType={userType} roomId={roomId} />
 
-        <ChatListContainer>
-          <ChatList messages={messages} />
-        </ChatListContainer>
+        <ChatList messages={messages} />
 
         <ChatInputContainer>
           <ChatInput worker={worker} userType={userType} roomId={roomId} />
@@ -42,6 +48,8 @@ export const ChatRoomLayout = ({ userType, roomId }: ChatRoomLayoutProps) => {
     </>
   );
 };
+
+export default memo(ChatRoomLayout);
 
 const ChatOpenBtn = styled.button<{ $isVisible: boolean }>`
   display: ${({ $isVisible }) => ($isVisible ? 'flex' : 'none')};
@@ -57,14 +65,6 @@ const ChatRoomContainer = styled.aside<{ $isVisible: boolean }>`
   max-width: 380px;
   border-left: 1px solid ${({ theme }) => theme.tokenColors['surface-alt']};
   background: ${({ theme }) => theme.tokenColors['surface-default']};
-`;
-
-const ChatListContainer = styled.div`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  justify-content: end;
-  overflow-y: auto;
 `;
 
 const ChatInputContainer = styled.div`

--- a/frontend/src/components/chat/ClientChatRoom.tsx
+++ b/frontend/src/components/chat/ClientChatRoom.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { ChatRoomLayout } from './ChatRoomLayout';
+import ChatRoomLayout from './ChatRoomLayout';
 
 import { ChatProvider } from 'src/contexts/chatContext';
 

--- a/frontend/src/components/chat/HostChatRoom.tsx
+++ b/frontend/src/components/chat/HostChatRoom.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ChatRoomLayout } from './ChatRoomLayout';
+import ChatRoomLayout from './ChatRoomLayout';
 import { getStoredId } from '@utils/id';
 import useFetchStreamKey from '@queries/host/useFetchStreamKey';
 import { ChatProvider } from 'src/contexts/chatContext';

--- a/frontend/src/components/chat/QuestionCard.tsx
+++ b/frontend/src/components/chat/QuestionCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 import styled from 'styled-components';
 import CheckIcon from '@assets/icons/check.svg';
 import { MessageReceiveData } from '@type/chat';
@@ -13,7 +13,7 @@ interface QuestionCardProps {
 }
 
 export const QuestionCard = ({ type, question, handleQuestionDone, ellipsis = false }: QuestionCardProps) => {
-  const startDateFormat = new Date(question.msgTime);
+  const startDateFormat = useMemo(() => new Date(question.msgTime), [question.msgTime]);
   const nowRef = useRef<Date>(new Date());
 
   const formatTime = useRef<string>(formatTimeDifference({ startDate: startDateFormat, now: nowRef.current }));
@@ -59,7 +59,7 @@ export const QuestionCard = ({ type, question, handleQuestionDone, ellipsis = fa
   );
 };
 
-export default QuestionCard;
+export default memo(QuestionCard);
 
 const QuestionCardContainer = styled.div`
   display: flex;

--- a/frontend/src/components/chat/QuestionCard.tsx
+++ b/frontend/src/components/chat/QuestionCard.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import CheckIcon from '@assets/icons/check.svg';
 import { MessageReceiveData } from '@type/chat';
 import QuestionUserIcon from '@assets/icons/question_user_icon.svg';
+import { formatTimeDifference } from '@utils/formatTimeDifference';
 
 interface QuestionCardProps {
   type: 'host' | 'client';
@@ -11,6 +13,29 @@ interface QuestionCardProps {
 }
 
 export const QuestionCard = ({ type, question, handleQuestionDone, ellipsis = false }: QuestionCardProps) => {
+  const startDateFormat = new Date(question.msgTime);
+  const nowRef = useRef<Date>(new Date());
+
+  const formatTime = useRef<string>(formatTimeDifference({ startDate: startDateFormat, now: nowRef.current }));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      nowRef.current = new Date();
+      const updatedTime = formatTimeDifference({ startDate: startDateFormat, now: nowRef.current });
+
+      if (formatTime.current !== updatedTime) {
+        formatTime.current = updatedTime;
+        if (timeElement.current) {
+          timeElement.current.innerText = updatedTime;
+        }
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [startDateFormat]);
+
+  const timeElement = useRef<HTMLSpanElement>(null);
+
   return (
     <QuestionCardContainer>
       <QuestionCardTop>
@@ -18,7 +43,9 @@ export const QuestionCard = ({ type, question, handleQuestionDone, ellipsis = fa
           <span className="name_info">
             <StyledIcon as={QuestionUserIcon} /> {question.nickname}
           </span>
-          <span className="time_info">n분전</span>
+          <span className="time_info" ref={timeElement}>
+            {formatTime.current}
+          </span>
         </QuestionInfo>
         {type === 'host' && handleQuestionDone && (
           <CheckBtn onClick={() => handleQuestionDone(question.questionId as number)}>
@@ -31,6 +58,7 @@ export const QuestionCard = ({ type, question, handleQuestionDone, ellipsis = fa
     </QuestionCardContainer>
   );
 };
+
 export default QuestionCard;
 
 const QuestionCardContainer = styled.div`

--- a/frontend/src/components/chat/QuestionCard.tsx
+++ b/frontend/src/components/chat/QuestionCard.tsx
@@ -82,15 +82,13 @@ const StyledCheckIcon = styled(CheckIcon)`
 `;
 
 const QuestionCardBottom = styled.div<{ $ellipsis: boolean }>`
-  /* max-height: 80px; */
-  overflow-y: scroll;
   ${({ theme }) => theme.tokenTypographys['display-bold14']}
   padding: 10px 15px 0 15px;
-  overflow-y: ${({ $ellipsis }) => ($ellipsis ? 'hidden' : 'scroll')};
   white-space: ${({ $ellipsis }) => ($ellipsis ? 'nowrap' : 'normal')};
   text-overflow: ${({ $ellipsis }) => ($ellipsis ? 'ellipsis' : 'clip')};
-  overflow-wrap: ${({ $ellipsis }) => ($ellipsis ? 'unset' : 'break-word')};
-  word-break: ${({ $ellipsis }) => ($ellipsis ? 'unset' : 'break-word')};
+  overflow-wrap: break-word;
+  word-break: break-word;
+  overflow: hidden;
 `;
 
 const StyledIcon = styled.svg`

--- a/frontend/src/components/client/ElapsedTime.tsx
+++ b/frontend/src/components/client/ElapsedTime.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { updateElapsedTime } from '@utils/updateElapsedTime';
 
 interface ElapsedTimeProps {
@@ -6,20 +6,24 @@ interface ElapsedTimeProps {
 }
 
 const ElapsedTime = ({ startDate }: ElapsedTimeProps) => {
-  const [elapsedTime, setElapsedTime] = useState<string>('00:00:00');
+  const elapsedTimeRef = useRef<string>('00:00:00');
   const startDateTime = new Date(startDate).getTime();
 
   useEffect(() => {
     const interval = setInterval(() => {
       const now = Date.now();
       const updatedTime = updateElapsedTime({ startDateTime, now });
-      setElapsedTime(updatedTime);
+
+      if (elapsedTimeRef.current !== updatedTime) {
+        elapsedTimeRef.current = updatedTime;
+        document.getElementById('elapsed-time')!.innerText = `${updatedTime} 스트리밍 중`;
+      }
     }, 1000);
 
     return () => clearInterval(interval);
   }, [startDate]);
 
-  return <span>{elapsedTime} 스트리밍 중</span>;
+  return <span id="elapsed-time">{elapsedTimeRef.current} 스트리밍 중</span>;
 };
 
 export default ElapsedTime;

--- a/frontend/src/utils/formatTimeDifference.ts
+++ b/frontend/src/utils/formatTimeDifference.ts
@@ -4,7 +4,9 @@ export const formatTimeDifference = ({ startDate, now }: { startDate: Date; now:
   const diffInMinutes = Math.floor(diffInMilliseconds / (1000 * 60));
   const diffInHours = Math.floor(diffInMilliseconds / (1000 * 60 * 60));
 
-  if (diffInMinutes < 60) {
+  if (diffInMilliseconds < 60 * 1000) {
+    return '방금 전';
+  } else if (diffInMinutes < 60) {
     return `${diffInMinutes}분 전`;
   } else if (diffInHours < 24) {
     return `${diffInHours}시간 전`;


### PR DESCRIPTION
## 🚀 Issue Number
<!-- - resolve: #{Number} -->
- resolve: #206 

## 주요 작업
<!-- 문제 상황 정의 -->
새로운 채팅이 올라올 때마다 이전 채팅이 계속해서 리렌더링 되는 문제

## 고민과 해결 과정
<!-- 변경 사항 -->
- [React.memo() 현명하게 사용하기](https://ui.toast.com/weekly-pick/ko_20190731)
- 렌더링 최적화를 제대로 진행하는 것은 처음이라 memo와 useCallback을 잘 활용하고 있는 것인지 헷갈렸던 것 같습니다. 우선 크게 렌더링 개선이 필요한 부분을 위주로 잡고 불필요한 memo는 제거해보는 방향으로 가보겠습니다.

- 스트리밍 시간의 리렌더링 이슈를 useRef를 활용한 비제어 컴포넌트로 변경해 개선
- 질문 카드의 시간 역시 useRef로 변경

- 이전 채팅 item의 경우 React.memo를 이용해 prop이 변경되지 않았다면 리렌더링 되지 않도록 개선할 수 있었습니다.

## 📸 Screenshots
왼쪽이 개선 전, 오른쪽이 개선 후 입니다.

- 비제어 컴포넌트로 개선

https://github.com/user-attachments/assets/50d234e1-bd5e-4736-bdb1-6302186b7c23

- 채팅창 개선

https://github.com/user-attachments/assets/7ca7ce24-b231-48fb-a36f-4f3fbd5bea9c


## 🔜 추가 내용 (선택)
