### PR TITLE
[REFACTOR] user ban 을 x-forwarded-for 에서 userAgent 로 변경

### DIFF
--- a/backend/chatServer/src/chat/chat.gateway.ts
+++ b/backend/chatServer/src/chat/chat.gateway.ts
@@ -178,10 +178,10 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
     if(!address) throw new ChatException(CHATTING_SOCKET_ERROR.INVALID_USER, roomId);
 
-    const forwarded = banUser?.handshake.headers.forwarded ?? address;
-    console.log('ban:', roomId, address, forwarded);
+    const userAgent = banUser?.handshake.headers['user-agent'];
+    if(!userAgent) throw new ChatException(CHATTING_SOCKET_ERROR.INVALID_USER, roomId);
 
-    await this.roomService.addUserToBlacklist(roomId, address, forwarded);
+    await this.roomService.addUserToBlacklist(roomId, address, userAgent);
     console.log(await this.roomService.getUserBlacklist(roomId, address));
   }
 }

--- a/backend/chatServer/src/room/room.repository.ts
+++ b/backend/chatServer/src/room/room.repository.ts
@@ -3,7 +3,7 @@ import { Cluster } from 'ioredis';
 import { QuestionDto } from '../event/dto/Question.dto';
 import { ChatException, CHATTING_SOCKET_ERROR } from '../chat/chat.error';
 
-type FORWARDED = string;
+type USER_AGENT = string;
 
 @Injectable()
 export class RoomRepository {
@@ -128,16 +128,16 @@ export class RoomRepository {
   }
 
 
-  async getUserBlacklist(roomId: string, address: string): Promise<FORWARDED[]> {
-    const userBlacklist = await this.lrange<FORWARDED[]>(this.getUserBlacklistInRoomWithPrefix(roomId, address), 0, -1);
+  async getUserBlacklist(roomId: string, address: string): Promise<USER_AGENT[]> {
+    const userBlacklist = await this.lrange<USER_AGENT[]>(this.getUserBlacklistInRoomWithPrefix(roomId, address), 0, -1);
     console.log('blacklist', userBlacklist);
     if (!userBlacklist) return [];
     return userBlacklist;
   }
 
-  async addUserBlacklistToRoom(roomId: string, address: string, forwarded: string){
-    console.log(roomId, address, forwarded);
+  async addUserBlacklistToRoom(roomId: string, address: string, userAgent: string){
+    console.log(roomId, address, userAgent);
     console.log(this.getUserBlacklistInRoomWithPrefix(roomId, address));
-    return this.redisClient.rpush(this.getUserBlacklistInRoomWithPrefix(roomId, address), forwarded);
+    return this.redisClient.rpush(this.getUserBlacklistInRoomWithPrefix(roomId, address), userAgent);
   }
 }

--- a/backend/chatServer/src/room/room.service.ts
+++ b/backend/chatServer/src/room/room.service.ts
@@ -174,7 +174,7 @@ export class RoomService implements OnModuleInit, OnModuleDestroy {
     return await this.redisRepository.getUserBlacklist(roomId, address);
   }
 
-  async addUserToBlacklist(roomId: string, address: string, forwarded: string){
-    return await this.redisRepository.addUserBlacklistToRoom(roomId, address, forwarded);
+  async addUserToBlacklist(roomId: string, address: string, userAgent: string){
+    return await this.redisRepository.addUserBlacklistToRoom(roomId, address, userAgent);
   }
 }


### PR DESCRIPTION
## 🚀 Issue Number
<!-- - resolve: #{Number} -->

## 주요 작업
<!-- 문제 상황 정의 -->
user ban 을 x-forwarded-for 에서 userAgent 로 변경

## 고민과 해결 과정
<!-- 변경 사항 -->
x-forwarded-for 로 할 경우, 같은 공유기 내부에서 전부 다 차단 당하는 경우가 있습니다.
따라서 x-forwarded-for 보다 조금 더 세밀하게 볼 수 있는 userAgent 로 변경했습니다.
userAgent 도 쉽게 조작할 수 있으나 x-forwarded-for 보다는 사용자 경험을 증진시킬 수 있습니다.

## 📸 Screenshots


## 🔜 추가 내용 (선택)
